### PR TITLE
fix(runner): Deadlock when draining

### DIFF
--- a/runner/cmd/runner/main.go
+++ b/runner/cmd/runner/main.go
@@ -40,7 +40,7 @@ func main() {
 	<-ctx.Done()
 	slog.Info("Received signal")
 	shouldShutdown = true
-	r.Drain()
+	r.Drain(ctx)
 
 	// let drainage propagate
 	time.Sleep(time.Second)

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -139,16 +139,19 @@ func (r *Runner) Run(ctx context.Context) {
 	}()
 }
 
-func (r *Runner) Drain() {
+func (r *Runner) Drain(ctx context.Context) {
 	r.log.Info("Runner set to drain.")
 	r.draining = true
-	r.notifications <- &protobuf.Notification{
+	select {
+	case r.notifications <- &protobuf.Notification{
 		Data: &protobuf.Notification_Heartbeat{
 			Heartbeat: &protobuf.HeartbeatNotification{
 				Hostname: ptr.Take(config.Config.Hostname),
 				Draining: ptr.Take(r.draining),
 			},
 		},
+	}:
+	case <-ctx.Done():
 	}
 }
 


### PR DESCRIPTION
  In main.go, when a signal is received:
  1. ctx is cancelled (via signal.NotifyContext)
  2. <-ctx.Done() unblocks in main
  3. r.Drain() is called

  But in runner.go, Drain() does a blocking send:
  r.notifications <- &protobuf.Notification{...}

  at the same time, handleNotifications is running a select over
  r.notifications and ctx.Done(). Since ctx is already cancelled when
  Drain() sends, handleNotifications may take the ctx.Done() branch
  and exit, leaving nobody reading from r.notifications. This
  deadlocks Drain(), so the main goroutine never reaches
  currentCount == 0
