### PR TITLE
fix: Add index on id/language on subtitle table

### DIFF
--- a/model/subtitles.go
+++ b/model/subtitles.go
@@ -8,9 +8,9 @@ import (
 type Subtitles struct {
 	gorm.Model
 
-	StreamID uint   `gorm:"not null"`
+	StreamID uint   `gorm:"not null;index:idx_subtitles_stream_id_language"`
 	Content  string `gorm:"not null"` // the .srt content provided by the voice-service
-	Language string `gorm:"not null"`
+	Language string `gorm:"not null;index:idx_subtitles_stream_id_language"`
 }
 
 // TableName returns the name of the table for the Subtitles model in the database.


### PR DESCRIPTION
we're seeing logs like this in prod:

```
2026-08-09 17:12:25.210 unk 2026/08/09 17:12:25 WARN slow sql query [11.613233922s >= 500ms] slow_query=true query="SELECT * FROM `stats` WHERE (live = 0 AND time BETWEEN '2026-08-09 17:00:00' and '2026-08-09 18:00:00') AND `stats`.`deleted_at` IS NULL ORDER BY `stats`.`id` LIMIT 1" duration=11.613233922s rows=1 file=/go/src/app/dao/streams.go:124 
```

The subtitle table is giant, but we only ever query by id and language. This adds an index on those. 