### PR TITLE
fix(runner): Handling the early end of a stream

### DIFF
--- a/pkg/runner_manager/manager.go
+++ b/pkg/runner_manager/manager.go
@@ -763,6 +763,11 @@ func (m *Manager) endRunnerJob(ctx context.Context, job model.StreamRunnerJob, d
 		DiscardVod: ptr.Take(discardVoD),
 	})
 	if err != nil {
+		// a job the runner doesn't know is already over, which is what we want anyway
+		if status.Code(err) == codes.NotFound {
+			m.logger.Info("runner does not know job, considering it ended", "runner", job.RunnerHostname, "job", job.JobID)
+			return nil
+		}
 		return fmt.Errorf("request stream end for job %s: %w", job.JobID, err)
 	}
 	return nil

--- a/runner/handlers.go
+++ b/runner/handlers.go
@@ -45,13 +45,13 @@ func (r *Runner) RequestStream(_ context.Context, req *protobuf.StreamRequest) (
 
 func (r *Runner) RequestStreamEnd(_ context.Context, req *protobuf.StreamEndRequest) (*protobuf.StreamEndResponse, error) {
 	r.jobsMu.Lock()
-	cancel, ok := r.jobs[req.GetJobId()]
+	j, ok := r.jobs[req.GetJobId()]
 	if ok {
-		r.discard[req.GetJobId()] = req.GetDiscardVod()
+		j.discard = req.GetDiscardVod()
 	}
 	r.jobsMu.Unlock()
 	if ok {
-		cancel()
+		j.endStream()
 		return &protobuf.StreamEndResponse{}, nil
 	}
 	return nil, status.Errorf(codes.NotFound, "job %s not found", req.GetJobId())

--- a/runner/handlers.go
+++ b/runner/handlers.go
@@ -26,12 +26,18 @@ func (r *Runner) RequestStream(_ context.Context, req *protobuf.StreamRequest) (
 	a := []actions.Action{
 		actions.Stream,
 		actions.StreamEnd,
+	}
+	vod := []actions.Action{
 		actions.MkVOD,
 		actions.CheckVoD,
 		actions.MkThumb,
 	}
+	// runs instead of vod if the stream is ended with discardVod
+	discard := []actions.Action{
+		actions.DiscardRecording,
+	}
 
-	jID := r.RunAction(a, data, r.log.With("stream_id", req.GetStreamId(), "stream_version", req.GetVersion(), "input", req.GetInput()))
+	jID := r.RunAction(a, vod, discard, data, r.log.With("stream_id", req.GetStreamId(), "stream_version", req.GetVersion(), "input", req.GetInput()))
 	r.log.Info("job added", "ID", jID)
 
 	return &protobuf.StreamResponse{JobId: ptr.Take(jID)}, nil
@@ -46,7 +52,7 @@ func (r *Runner) RequestStreamEnd(_ context.Context, req *protobuf.StreamEndRequ
 	r.jobsMu.Unlock()
 	if ok {
 		cancel()
-		return nil, nil
+		return &protobuf.StreamEndResponse{}, nil
 	}
-	return nil, status.Errorf(codes.NotFound, "stream not found")
+	return nil, status.Errorf(codes.NotFound, "job %s not found", req.GetJobId())
 }

--- a/runner/pkg/actions/actions.go
+++ b/runner/pkg/actions/actions.go
@@ -13,5 +13,6 @@ import (
 // An action takes a context ctx, may cancel the action.
 // Actions should use log for logging and notify for sending messages like their progress to gocast.
 // d contains data passed to the action and is used to pass data to the next actions.
-// Any error, the action returns will be logged. If that error is an AbortingError, the subsequent actions will be skipped.
+// Any error, the action returns will be logged. If that error is an AbortingError, the action is not
+// retried. The actions after it still run, RunAction relies on that to end streams early.
 type Action func(ctx context.Context, log *slog.Logger, notify chan *protobuf.Notification, d map[string]any, metrics *metrics.Broker) error

--- a/runner/pkg/actions/discard.go
+++ b/runner/pkg/actions/discard.go
@@ -1,0 +1,22 @@
+package actions
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/tum-dev/gocast/runner/pkg/metrics"
+	"github.com/tum-dev/gocast/runner/protobuf"
+)
+
+// DiscardRecording marks the live recording for deletion instead of turning it into a VoD.
+// It runs in place of MkVOD/CheckVoD/MkThumb when a stream was ended with discardVod.
+func DiscardRecording(_ context.Context, log *slog.Logger, _ chan *protobuf.Notification, d map[string]any, _ *metrics.Broker) error {
+	recordingDir, ok := d["recordingDir"].(string)
+	if !ok {
+		return AbortingError(fmt.Errorf("no recordingDir in context"))
+	}
+	log.Info("marking recording for deletion", "dir", recordingDir)
+	return writeManagementFile(recordingDir, fmt.Sprintf(".del-%d", time.Now().Unix()))
+}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -46,8 +46,7 @@ type Runner struct {
 	draining bool
 	JobCount chan int
 	jobsMu   sync.Mutex
-	jobs     map[string]context.CancelFunc
-	discard  map[string]bool
+	jobs     map[string]*job
 
 	hlsServer *HLSServer
 
@@ -76,8 +75,7 @@ func NewRunner(v string) *Runner {
 	return &Runner{
 		log:           log,
 		JobCount:      make(chan int),
-		jobs:          make(map[string]context.CancelFunc),
-		discard:       make(map[string]bool),
+		jobs:          make(map[string]*job),
 		draining:      false,
 		hlsServer:     NewHLSServer(config.Config.SegmentPath, log.WithGroup("HLSServer"), v),
 		stats:         vmstats,
@@ -178,32 +176,41 @@ func (r *Runner) InitApiGrpc() {
 	}
 }
 
+// job is a running set of actions. endStream stops the live capture, cancel stops the whole job
+// and is only used on shutdown.
+type job struct {
+	endStream context.CancelFunc
+	cancel    context.CancelFunc
+	discard   bool
+}
+
 // RunAction runs a in the background and returns the id of the created job.
-// The actions in a run even after the job was cancelled, afterwards either vod or discard runs.
+// The actions in a run even after the stream was ended, afterwards either vod or discard runs.
 func (r *Runner) RunAction(a, vod, discard []actions.Action, data map[string]any, logger *slog.Logger) string {
 	// create new context to avoid cancellation on grpc request termination
-	c, cancel := context.WithCancel(context.Background())
-	job := uuid.New().String()
+	jobCtx, cancel := context.WithCancel(context.Background())
+	// ending a stream early only stops the capture, the post processing still has to run
+	streamCtx, endStream := context.WithCancel(jobCtx)
+	id := uuid.New().String()
 	r.JobCount <- 1
 	r.jobsMu.Lock()
-	r.jobs[job] = cancel
+	r.jobs[id] = &job{endStream: endStream, cancel: cancel}
 	r.jobsMu.Unlock()
 	go func() {
 		defer func() {
 			cancel()
 			r.jobsMu.Lock()
-			delete(r.jobs, job)
-			delete(r.discard, job)
+			delete(r.jobs, id)
 			r.jobsMu.Unlock()
 			r.JobCount <- -1
 		}()
 
-		run := func(action actions.Action) {
+		run := func(ctx context.Context, action actions.Action) {
 			for {
-				log := logger.With("action", getFunctionName(action)).With("job", job)
+				log := logger.With("action", getFunctionName(action)).With("job", id)
 				log.Info("running action")
 				s := time.Now()
-				err := action(c, log, r.notifications, data, r.Metrics)
+				err := action(ctx, log, r.notifications, data, r.Metrics)
 				log.Info("action completed", "duration", time.Since(s).String())
 				if err != nil {
 					log.Error("action error", "error", err) // use action specific logger
@@ -218,24 +225,25 @@ func (r *Runner) RunAction(a, vod, discard []actions.Action, data map[string]any
 		}
 
 		for _, action := range a {
-			run(action)
+			run(streamCtx, action)
 		}
 		next := vod
-		if r.discarded(job) {
-			logger.With("job", job).Info("discarding recording, skipping VoD creation")
+		if r.discarded(id) {
+			logger.With("job", id).Info("discarding recording, skipping VoD creation")
 			next = discard
 		}
 		for _, action := range next {
-			run(action)
+			run(jobCtx, action)
 		}
 	}()
-	return job
+	return id
 }
 
-func (r *Runner) discarded(job string) bool {
+func (r *Runner) discarded(id string) bool {
 	r.jobsMu.Lock()
 	defer r.jobsMu.Unlock()
-	return r.discard[job]
+	j, ok := r.jobs[id]
+	return ok && j.discard
 }
 
 func (r *Runner) handleNotifications(ctx context.Context) {
@@ -309,8 +317,8 @@ func getFunctionName(i interface{}) string {
 // it cancels all running actions
 func (r *Runner) Cleanup() {
 	r.jobsMu.Lock()
-	for _, cancelFunc := range r.jobs {
-		cancelFunc()
+	for _, j := range r.jobs {
+		j.cancel()
 	}
 	r.jobsMu.Unlock()
 	// sleep 1 second longer than our commands default waitDelay

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -178,7 +178,9 @@ func (r *Runner) InitApiGrpc() {
 	}
 }
 
-func (r *Runner) RunAction(a []actions.Action, data map[string]any, logger *slog.Logger) string {
+// RunAction runs a in the background and returns the id of the created job.
+// The actions in a run even after the job was cancelled, afterwards either vod or discard runs.
+func (r *Runner) RunAction(a, vod, discard []actions.Action, data map[string]any, logger *slog.Logger) string {
 	// create new context to avoid cancellation on grpc request termination
 	c, cancel := context.WithCancel(context.Background())
 	job := uuid.New().String()
@@ -195,7 +197,8 @@ func (r *Runner) RunAction(a []actions.Action, data map[string]any, logger *slog
 			r.jobsMu.Unlock()
 			r.JobCount <- -1
 		}()
-		for _, action := range a {
+
+		run := func(action actions.Action) {
 			for {
 				log := logger.With("action", getFunctionName(action)).With("job", job)
 				log.Info("running action")
@@ -206,24 +209,33 @@ func (r *Runner) RunAction(a []actions.Action, data map[string]any, logger *slog
 					log.Error("action error", "error", err) // use action specific logger
 					if actions.IsAbortingError(err) {
 						log.Info("action can't continue")
-						break // escape retry loop on unrecoverable error
+						return // escape retry loop on unrecoverable error
 					}
 				} else {
-					break // escape retry loop on no error
+					return // escape retry loop on no error
 				}
 			}
-			// VoD creation (MkVOD, CheckVoD, MkThumb) is intentionally skipped once the
-			// recording is discarded, right after StreamEnd notifies gocast the stream has ended.
-			r.jobsMu.Lock()
-			shouldDiscard := r.discard[job]
-			r.jobsMu.Unlock()
-			if shouldDiscard && reflect.ValueOf(action).Pointer() == reflect.ValueOf(actions.StreamEnd).Pointer() {
-				logger.With("job", job).Info("discarding recording, skipping VoD creation")
-				break
-			}
+		}
+
+		for _, action := range a {
+			run(action)
+		}
+		next := vod
+		if r.discarded(job) {
+			logger.With("job", job).Info("discarding recording, skipping VoD creation")
+			next = discard
+		}
+		for _, action := range next {
+			run(action)
 		}
 	}()
 	return job
+}
+
+func (r *Runner) discarded(job string) bool {
+	r.jobsMu.Lock()
+	defer r.jobsMu.Unlock()
+	return r.discard[job]
 }
 
 func (r *Runner) handleNotifications(ctx context.Context) {


### PR DESCRIPTION
### Motivation and Context
If a lecturer ends the stream early and not discard it, it will not create a VoD.

### Steps for Testing

1. Create a stream and end it early.
2. The runner should create the VoD.