### PR TITLE
fix(e2e): seed the fixture in the host's time zone

### DIFF
--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -66,10 +66,19 @@ jobs:
       # Run through the mariadb image rather than a client on the runner, so the client
       # version always matches the server and nothing depends on what happens to be
       # preinstalled.
+      #
+      # The dump dates its lectures off the clock, which MariaDB evaluates in the
+      # session's time zone -- and the server reads those columns back as local time
+      # while the browser judges "today" in its own. Pin the session to the runner's
+      # offset so the three agree. The runner and the container are both UTC today, so
+      # this changes nothing here; it keeps the step honest about what it depends on,
+      # and matches what `make e2e_db` does for a developer whose host is not UTC.
       - name: Seed the database
         run: |
-          docker run --rm --network host -v "$PWD:/repo:ro" mariadb:11 \
-            sh -c 'mariadb -h 127.0.0.1 -P 3306 -u root -pexample < /repo/tum-live-starter.sql'
+          offset=$(date +%z | sed 's/..$/:&/')
+          { echo "SET time_zone = '$offset';"; cat tum-live-starter.sql; } | \
+            docker run --rm -i --network host mariadb:11 \
+              mariadb -h 127.0.0.1 -P 3306 -u root -pexample
 
       # web/router.go embeds web/node_modules, so this is needed to compile at all, not
       # just to make the icons show up.

--- a/Makefile
+++ b/Makefile
@@ -73,13 +73,28 @@ test:
 #   make e2e_db DB_CONTAINER=mariadb_container
 DB_CONTAINER ?= mariadb-tumlive
 
+# The dump dates its lectures off the clock -- NOW() and CURDATE() -- which MariaDB
+# evaluates in the session's time zone. The server then reads those columns back as
+# local time (loc=Local, cmd/tumlive/main.go) and the browser judges "today" in its
+# own, so all three have to agree on what day it is. They do not by default: the
+# database usually runs UTC inside its container while the host does not, and every
+# fixture date lands off by that offset -- far enough that the evening lecture the
+# "Today" test wants is dated to yesterday, and the waiting-room lecture meant to
+# start in 25 minutes has already ended. Pin the seeding session to this host's
+# offset instead, which puts the whole fixture back in the frame the tests read it in.
+#
+# date(1) prints +0200; MariaDB wants +02:00. Done with sed rather than date's %:z,
+# which GNU date has and BSD date does not.
+HOST_TZ_OFFSET = $(shell date +%z | sed 's/..$$/:&/')
+
 .PHONY: e2e_db
 e2e_db:
 	@docker inspect -f . $(DB_CONTAINER) >/dev/null 2>&1 || { \
 		echo "no container named $(DB_CONTAINER); pass DB_CONTAINER=<name>"; exit 1; }
 	docker exec -i $(DB_CONTAINER) mariadb -uroot -pexample \
 		-e "DROP DATABASE IF EXISTS tumlive;"
-	docker exec -i $(DB_CONTAINER) mariadb -uroot -pexample < tum-live-starter.sql
+	{ echo "SET time_zone = '$(HOST_TZ_OFFSET)';"; cat tum-live-starter.sql; } | \
+		docker exec -i $(DB_CONTAINER) mariadb -uroot -pexample
 
 # Browser tests against a running server. Not part of `test`: these need the server and
 # its database up.

--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -193,6 +193,12 @@ export const unlistedLecture = "VL 3: Rückblick";
  *
  * Their dates are relative to when the dump was loaded, because "today" cannot be
  * written as a fixed date. Reload with `make e2e_db` before a run.
+ *
+ * Load it that way and not with a bare `mariadb < tum-live-starter.sql`: the dump's
+ * NOW() and CURDATE() are evaluated in the session's time zone, and the database
+ * container is usually UTC while the server that reads the dates back is not. The
+ * make target pins the session to the host's offset, which is what keeps the lecture
+ * below on today rather than on whichever day it is in UTC.
  */
 export const schedule = {
   /** Later today, so the start page has something under "Today". */


### PR DESCRIPTION
## The problem

`visibility.spec.ts > today's lecture is listed under Today` fails locally for anyone whose host is not UTC, on a fixture that is hours in the past.

The starter dump dates its lectures off the clock — `NOW()` and `CURDATE()` — which **MariaDB** evaluates in the session's time zone. The server then reads those columns back as local time (`loc=Local`, `cmd/tumlive/main.go`), and the browser decides what "today" means in its own (`HomeView.vue`, `isToday(...) && minutesUntilStart(...) > 0`). Three clocks that have to agree on what day it is — and don't, because the database runs UTC inside its container while the developer's host generally does not.

The test's skip guard does not cover this: it reads the host clock and only skips after 23:45, while the lecture it is guarding was written against the container's.

It is not one lecture, either. The same offset moves **every** relative date in the dump, including the waiting-room lecture meant to start in 25 minutes (`tum-live-starter.sql:1047`), which a large enough offset turns into one that has already ended. That test has been passing by luck rather than by correctness.

## The fix

Pin the **seeding session** to the host's offset rather than editing the dates. One lever puts the whole fixture back into the frame the tests read it in, instead of repairing one lecture and leaving the rest skewed.

- `Makefile` — `HOST_TZ_OFFSET` from `date +%z | sed 's/..$/:&/'` (sed rather than `date`'s `%:z`, which GNU date has and BSD date does not), prepended as a `SET time_zone` statement to the piped dump.
- `.github/workflows/frontend-test.yml` — the same for the CI seed step.
- `frontend/e2e/seed.ts` — documents why a bare `mariadb < tum-live-starter.sql` reintroduces the bug.

## CI behaviour is unchanged

The runner and the service container are both UTC, so the offset CI computes is `+00:00`. The step is changed anyway so that it states the dependency it has always had, and so it matches what `make e2e_db` gives a developer whose host is not UTC.

## Verification

The cause was isolated rather than inferred from a green run — the first apparently-fixed attempt still failed, which turned out to be a re-seed without the server restart that migrates the 2022 schema forward. Controlling for that, on the same container and the same server binary:

| Seeding session time zone | Result |
| --- | --- |
| `-10:00` (forced divergence), fresh server | ✘ fails — lecture dated to yesterday, `#live-today` absent |
| `make e2e_db` (pins `+02:00`), fresh server | ✓ passes |

Identical procedure in both directions; only the seeding time zone differed.

- Full e2e suite: **122/122 pass**, including the waiting-room test.
- The rewritten CI seed command was run verbatim against a real container to confirm the stdin-piped form works.

## Deliberately left alone

If the database is seeded on an earlier day and not reloaded, the test still fails rather than skipping. That is the stale-fixture case the Makefile already warns about, and other tests in the suite mutate state too, so failing loudly seems right — happy to make it skip instead if reviewers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
