### PR TITLE
docs: add AGENTS.md and a local-testing skill

### DIFF
--- a/.claude/skills/local-testing/SKILL.md
+++ b/.claude/skills/local-testing/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: local-testing
+description: Run GoCast's checks and bring the stack up locally to verify a change in a real browser — Go tests, frontend unit tests, lint, Playwright e2e, and screenshot-based visual regression against a baseline branch. Use when asked to test, run, or visually verify GoCast, when a change touches CSS, Tailwind config or templates, or when a dependency bump needs proving beyond CI.
+---
+
+# Testing GoCast locally
+
+CI covers compile-and-assert. It cannot see layout, colour, or anything that only
+appears once the app is in a browser — which is where the expensive regressions
+live. This skill covers both halves.
+
+## The fast checks
+
+Run these first; they need no database and catch most things.
+
+```bash
+go test -race ./...                  # or: make test  (also runs frontend unit tests)
+npm --prefix frontend test           # 166 vitest tests, ~2s
+npm --prefix frontend run typecheck  # vue-tsc
+npm --prefix web run lint            # eslint, flat config
+make lint                            # golangci-lint + the two above
+```
+
+`npm --prefix web run lint` lints `ts/` only — deliberately. `eslint .` also walks
+`spa/assets`, and running prettier over the minified Vite bundle there pegs a core
+indefinitely. Keep the script's path argument; don't "fix" it back to `.`.
+
+## Bringing up the stack
+
+Four steps, in order. Steps 2 and 3 are not optional — skipping them silently
+changes what you are looking at.
+
+**1. Database.** The starter dump is the fixture every browser test asserts on.
+
+```bash
+docker run --detach --name mariadb-tumlive \
+  --env MARIADB_USER=root --env MARIADB_ROOT_PASSWORD=example \
+  -e TZ="$(cat /etc/timezone)" -p 3306:3306 \
+  --volume "$PWD"/tum-live-starter.sql:/init.sql \
+  mariadb:latest --init-file /init.sql
+
+make e2e_db DB_CONTAINER=mariadb-tumlive   # reseed; rerun after anything mutates settings
+```
+
+`make e2e_db` pins the seeding session to the host's UTC offset. The dump dates its
+lectures off `NOW()`, the server reads them back as local time, and the browser judges
+"today" in its own — all three have to agree or the "today" fixtures land on the wrong
+day. Don't seed by piping the dump in directly.
+
+**2. Assets.** `web/router.go` embeds `web/node_modules`, so the Go build *fails*
+without step one of these. Without the SPA build, every migrated route silently falls
+back to its old template — you would be testing the frontend being replaced.
+
+```bash
+npm --prefix web ci && npm --prefix web run build && npm --prefix web run tailwind-compile
+npm --prefix frontend ci && npm --prefix frontend run build
+```
+
+**3. Server.** Config comes from `./config.yaml` at the repo root.
+
+```bash
+go run cmd/tumlive/main.go > server.log 2>&1 &
+until curl -fsS -o /dev/null http://localhost:8081/login; do sleep 2; done
+```
+
+First boot compiles and migrates — allow a minute. Meilisearch `connection refused`
+warnings are expected and harmless; search just won't work. Leave the `ldap:` block in
+`config.yaml` commented out: with `useForLogin` set, every rejected password falls back
+to LDAP and hangs if the host doesn't resolve.
+
+**4. Log in.** Accounts are `admin`, `prof1`, `prof2`, `studi1`, `studi2`, `studi3`,
+all with password `password`. The login field is the users table's `email` column, not
+`name`. Roles: 1 admin, 2 lecturer, 4 student.
+
+Useful URLs: `/`, `/course/2022/S/brauereiwesen`, `/w/brauereiwesen/2`, `/admin`,
+`/admin/course/1`, `/admin/units/1/1`, `/admin/cut/1/1`. Courses in the fixture are
+`brauereiwesen`, `games101`, `godev` (2021/W), `bierkunde`, `geheim`.
+
+**There is no `/schedule` route** — `/admin` *is* the schedule page. `/schedule`
+renders the 404 template, whose animated GIF also makes it diff against itself.
+
+## Driving it in a browser
+
+Three scripts in `scripts/`. They find the repo root themselves, so run them from
+anywhere in the tree.
+
+```bash
+node .claude/skills/local-testing/scripts/capture.mjs <label> [path...]
+node .claude/skills/local-testing/scripts/compare.mjs <baseline> <candidate>
+node .claude/skills/local-testing/scripts/matched-rules.mjs <path> <selector> <property>
+```
+
+`capture.mjs` logs in, screenshots 14 pages in light and dark into `.shots/`, and
+reports two things a screenshot alone won't tell you: horizontal overflow
+(`scrollWidth > clientWidth`) and **error pages**. The 404 and permission templates
+render with HTTP 200, so a screenshot of one looks exactly like a pass. Trust no diff
+from a run that reported either.
+
+Playwright is a dependency of `frontend/` and the package is `@playwright/test` — not
+`playwright`, which fails with `ERR_MODULE_NOT_FOUND` even though the browsers are
+installed. `lib.mjs` resolves it by path for scripts living outside `frontend/`.
+
+## Visual regression against a baseline
+
+This is the part CI cannot do, and it is how every bug below was found. Comparing a
+change against *itself* proves nothing; compare it against `dev`.
+
+```bash
+git switch dev && npm --prefix web ci && npm --prefix web run build \
+  && npm --prefix web run tailwind-compile && npm --prefix frontend ci \
+  && npm --prefix frontend run build
+# restart the server, then:
+node .claude/skills/local-testing/scripts/capture.mjs base
+
+git switch -                                        # back to your branch, rebuild, restart
+node .claude/skills/local-testing/scripts/capture.mjs mine
+node .claude/skills/local-testing/scripts/compare.mjs base mine
+```
+
+Read the output like this:
+
+- **SIZE MISMATCH** — the layout moved. Always a regression; start here.
+- **> ~1%** — something structural. Open both images.
+- **< ~1% spread evenly** — usually palette or font rounding. Sample a few pixels
+  before dismissing it, and check whether the project's *own* configured colours
+  moved: if they did, it is not just rounding.
+
+Restart the Go server after rebuilding assets — templates are embedded in the binary.
+
+## Debugging a layout difference
+
+When an element is the wrong size and the utility class controlling it looks right,
+`matched-rules.mjs` prints every rule setting that property **with its cascade layer**:
+
+```
+$ node .claude/skills/local-testing/scripts/matched-rules.mjs /w/brauereiwesen/2 video-js.video-js width
+  .video-js                width:300px    layer=(none)
+  .video-comb-dimensions   width:1920px   layer=(none)
+  .w-full                  width:100%     layer=(none)
+computed: 1438px
+```
+
+The `layer` column answers more questions than specificity does.
+
+## Things CI cannot catch, learned the hard way
+
+These are real regressions that shipped green through every job.
+
+**Cascade layers beat specificity and order.** `@import "tailwindcss"` puts every
+utility in `@layer utilities`, and a layered rule loses to an unlayered one no matter
+what. Every vendor stylesheet this app links — video.js, videojs-seek-buttons,
+silvermine-airplay, fullcalendar, flatpickr, nouislider — is unlayered, so *any*
+utility on an element they also style loses. It surfaced as video.js sizing its player
+1920px wide over `w-full`, but the quiet cases are everywhere the two meet. Hence the
+hand-composed entry in `web/assets/css/{main,home}.css`: theme and preflight layered,
+utilities not. **If you ever restore a plain `@import "tailwindcss"`, re-run the visual
+diff** — this breakage is invisible to lint, tests and typecheck.
+
+**A class that does nothing is not a class that does nothing forever.**
+`min-w-screen` was never a Tailwind 3 utility, so four admin templates rendered as
+though it were absent for years. Tailwind 4 defines it, and those pages jumped 320px
+past the viewport. When a major version lands, the risk is not only renamed classes —
+it is dead ones coming alive. Grep templates for classes that produce no CSS in the
+*old* version.
+
+**Default tokens move between majors.** Tailwind 4's default sans stack drops
+`ui-sans-serif` and `system-ui`, which on Linux picks a different face and reflows
+text everywhere. The v3 stack is pinned in both `tailwind.config.js` files with a
+comment; deleting it is a deliberate visual decision, not a cleanup.
+
+**Utility scales get reused at new values.** v4 kept the names `shadow-sm`,
+`rounded-sm`, `blur-sm` and `outline-none` but changed what they mean. Verify by
+diffing compiled CSS between versions rather than trusting a changelog — and note
+that `@tailwindcss/upgrade` skips these codemods if the new version is already
+installed, which is exactly when you would be running it.
+
+## Playwright e2e
+
+```bash
+make e2e_db DB_CONTAINER=mariadb-tumlive   # and again whenever a run leaves settings changed
+make run                                    # in another terminal
+make test_e2e
+```
+
+Not part of `make test`: these need the server and its database up.
+
+## Shell gotchas
+
+- `pkill -f cmd/tumlive/main.go` does **not** stop the server. `go run` executes a
+  compiled binary elsewhere; kill it by port:
+  `kill "$(ss -lptn 'sport = :8081' | grep -oP 'pid=\K[0-9]+' | head -1)"`
+- Under zsh, `kill -0 "$(cat server.pid)"` in a readiness loop floods
+  `Too many arguments`. Use an `until curl ...; do sleep 2; done` loop instead.
+- `.shots/` is scratch output; keep it out of commits.

--- a/.claude/skills/local-testing/scripts/capture.mjs
+++ b/.claude/skills/local-testing/scripts/capture.mjs
@@ -1,0 +1,47 @@
+// Screenshot every page in both themes and report horizontal overflow.
+//
+//   node .claude/skills/local-testing/scripts/capture.mjs <label> [path...]
+//
+// Writes .shots/<label>-<page>-<theme>.png. Overflow is printed, not just drawn:
+// a page whose scrollWidth exceeds the viewport is a layout regression whatever it
+// looks like, and it is the failure mode CSS changes produce most often.
+import fs from "node:fs";
+import { chromium, BASE, login, PAGES, SHOTS } from "./lib.mjs";
+
+const label = process.argv[2];
+if (!label) { console.error("usage: capture.mjs <label> [path...]"); process.exit(1); }
+const pages = process.argv.length > 3 ? process.argv.slice(3).map((p) => [p.replace(/\W+/g, "-").replace(/^-|-$/g, "") || "root", p]) : PAGES;
+
+fs.mkdirSync(SHOTS, { recursive: true });
+const browser = await (await chromium()).launch();
+const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+const page = await ctx.newPage();
+await login(page);
+
+let overflows = 0, errors = 0;
+for (const [name, p] of pages) {
+  for (const theme of ["light", "dark"]) {
+    try {
+      await page.goto(BASE + p, { waitUntil: "networkidle", timeout: 25000 });
+      // Dark mode is a `dark` class on <html>, set per template and toggled by Alpine.
+      await page.evaluate((t) => document.documentElement.classList.toggle("dark", t === "dark"), theme);
+      await page.waitForTimeout(500);
+      const m = await page.evaluate(() => ({
+        doc: document.documentElement.scrollWidth,
+        vw: document.documentElement.clientWidth,
+        // The 404 and error templates render with HTTP 200, so the status code does
+        // not give this away: a screenshot of an error page looks like a pass.
+        err: /Error: \d{3}|This page does not exist|You are not allowed/.test(document.body.innerText),
+      }));
+      if (m.err) { errors++; console.log(`  !! ${name}/${theme}: ERROR PAGE (served with HTTP 200) -- wrong path, or not logged in?`); }
+      if (m.doc > m.vw) { overflows++; console.log(`  OVERFLOW ${name}/${theme}: scrollWidth=${m.doc} > viewport=${m.vw}`); }
+      await page.screenshot({ path: `${SHOTS}/${label}-${name}-${theme}.png` });
+    } catch (e) {
+      console.log(`  !! ${name}/${theme}: ${e.message.split("\n")[0]}`);
+    }
+  }
+  console.log(`shot ${name}`);
+}
+await browser.close();
+console.log(overflows ? `\n${overflows} page(s) overflow horizontally` : "\nno horizontal overflow");
+if (errors) console.log(`${errors} capture(s) are error pages -- fix the path or the login before trusting any diff`);

--- a/.claude/skills/local-testing/scripts/compare.mjs
+++ b/.claude/skills/local-testing/scripts/compare.mjs
@@ -1,0 +1,38 @@
+// Pixel-diff two capture runs.
+//
+//   node .claude/skills/local-testing/scripts/compare.mjs <baseline> <candidate>
+//
+// Prints the share of differing pixels per page, worst first, and flags size
+// mismatches separately -- those mean the layout moved, not just the colours.
+import fs from "node:fs";
+import { chromium, SHOTS } from "./lib.mjs";
+
+const [a, b] = process.argv.slice(2);
+if (!a || !b) { console.error("usage: compare.mjs <baseline> <candidate>"); process.exit(1); }
+const names = fs.readdirSync(SHOTS).filter((f) => f.startsWith(`${a}-`)).map((f) => f.slice(a.length + 1, -4));
+if (!names.length) { console.error(`no shots for "${a}" in ${SHOTS}`); process.exit(1); }
+
+const browser = await (await chromium()).launch();
+const page = await browser.newPage();
+await page.goto("about:blank");
+const rows = [];
+for (const n of names) {
+  const fa = `${SHOTS}/${a}-${n}.png`, fb = `${SHOTS}/${b}-${n}.png`;
+  if (!fs.existsSync(fb)) { rows.push([n, -1, `missing ${b}-${n}.png`]); continue; }
+  const r = await page.evaluate(async ([da, db]) => {
+    const load = (d) => new Promise((res) => { const i = new Image(); i.onload = () => res(i); i.src = d; });
+    const [ia, ib] = await Promise.all([load(da), load(db)]);
+    if (ia.width !== ib.width || ia.height !== ib.height) return { size: `${ia.width}x${ia.height} vs ${ib.width}x${ib.height}` };
+    const data = (im) => { const c = document.createElement("canvas"); c.width = im.width; c.height = im.height;
+      const g = c.getContext("2d"); g.drawImage(im, 0, 0); return g.getImageData(0, 0, c.width, c.height).data; };
+    const pa = data(ia), pb = data(ib);
+    let d = 0;
+    for (let i = 0; i < pa.length; i += 4)
+      if (Math.abs(pa[i] - pb[i]) > 8 || Math.abs(pa[i + 1] - pb[i + 1]) > 8 || Math.abs(pa[i + 2] - pb[i + 2]) > 8) d++;
+    return { pct: (d / (pa.length / 4)) * 100 };
+  }, [`data:image/png;base64,${fs.readFileSync(fa).toString("base64")}`, `data:image/png;base64,${fs.readFileSync(fb).toString("base64")}`]);
+  rows.push(r.size ? [n, 1e9, `SIZE MISMATCH ${r.size} -- layout moved`] : [n, r.pct, `${r.pct.toFixed(2)}%`]);
+}
+rows.sort((x, y) => y[1] - x[1]);
+for (const [n, , text] of rows) console.log(`  ${n.padEnd(24)} ${text}`);
+await browser.close();

--- a/.claude/skills/local-testing/scripts/lib.mjs
+++ b/.claude/skills/local-testing/scripts/lib.mjs
@@ -1,0 +1,62 @@
+// Shared plumbing for the browser scripts.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function repoRoot() {
+  let d = path.dirname(fileURLToPath(import.meta.url));
+  while (d !== "/") {
+    if (fs.existsSync(path.join(d, "go.mod")) && fs.existsSync(path.join(d, "frontend"))) return d;
+    d = path.dirname(d);
+  }
+  throw new Error("could not find the repo root (looked for go.mod next to frontend/)");
+}
+
+// Playwright is a dependency of frontend/, and these scripts live outside it. The
+// package is `@playwright/test`, not `playwright` -- importing the latter fails with
+// ERR_MODULE_NOT_FOUND even though the browsers are installed.
+export async function chromium() {
+  const entry = path.join(repoRoot(), "frontend/node_modules/@playwright/test/index.mjs");
+  if (!fs.existsSync(entry)) throw new Error(`playwright not installed; run: npm --prefix ${repoRoot()}/frontend ci`);
+  return (await import(entry)).chromium;
+}
+
+export const BASE = process.env.GOCAST_BASE || "http://localhost:8081";
+
+// Every fixture account uses the password "password"; the login field is the users
+// table's `email` column: admin, prof1, prof2, studi1, studi2, studi3.
+export async function login(page, who = "admin") {
+  await page.goto(`${BASE}/login`, { waitUntil: "networkidle" });
+  const user = page.locator('input[name="username"], input[type="text"]').first();
+  if (!(await user.count())) throw new Error("no login form at /login -- is the server up?");
+  await user.fill(who);
+  await page.locator('input[type="password"]').first().fill("password");
+  await Promise.all([
+    page.waitForLoadState("networkidle"),
+    page.locator('button[type="submit"], input[type="submit"]').first().click(),
+  ]);
+  if (page.url().includes("/login")) throw new Error(`login as ${who} failed -- reseed with: make e2e_db DB_CONTAINER=mariadb-tumlive`);
+}
+
+// Pages worth looking at, all reachable with the starter fixture. Everything under
+// /admin needs the login. There is no /schedule route -- /admin *is* the schedule
+// page (see GetPageString in web/admin.go), and /schedule renders the 404 page,
+// whose animated GIF also makes it diff against itself.
+export const PAGES = [
+  ["login", "/login"],
+  ["home", "/"],
+  ["about", "/about"],
+  ["search", "/search?q=bier"],
+  ["course", "/course/2022/S/brauereiwesen"],
+  ["watch", "/w/brauereiwesen/2"],
+  ["admin-schedule", "/admin"],
+  ["admin-course", "/admin/course/1"],
+  ["admin-create-course", "/admin/create-course"],
+  ["admin-course-import", "/admin/course-import"],
+  ["admin-users", "/admin/users"],
+  ["admin-lecture-halls", "/admin/lectureHalls"],
+  ["lecture-units", "/admin/units/1/1"],
+  ["lecture-cut", "/admin/cut/1/1"],
+];
+
+export const SHOTS = path.join(repoRoot(), ".shots");

--- a/.claude/skills/local-testing/scripts/matched-rules.mjs
+++ b/.claude/skills/local-testing/scripts/matched-rules.mjs
@@ -1,0 +1,34 @@
+// List every CSS rule setting a property on an element, with its cascade layer.
+//
+//   node .claude/skills/local-testing/scripts/matched-rules.mjs <path> <selector> <property>
+//   node .claude/skills/local-testing/scripts/matched-rules.mjs /w/brauereiwesen/2 video-js.video-js width
+//
+// Use when an element is the wrong size or colour and the utility class that should
+// control it looks correct. The `layer` column is the answer more often than
+// specificity: an unlayered rule beats a layered one no matter the order.
+import { chromium, BASE, login } from "./lib.mjs";
+
+const [path_, selector, prop] = process.argv.slice(2);
+if (!path_ || !selector || !prop) { console.error("usage: matched-rules.mjs <path> <selector> <property>"); process.exit(1); }
+
+const browser = await (await chromium()).launch();
+const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+const page = await ctx.newPage();
+await login(page);
+await page.goto(BASE + path_, { waitUntil: "networkidle" });
+await page.waitForTimeout(900);
+
+const cdp = await ctx.newCDPSession(page);
+await cdp.send("DOM.enable"); await cdp.send("CSS.enable");
+const { root } = await cdp.send("DOM.getDocument", { depth: -1, pierce: true });
+const { nodeId } = await cdp.send("DOM.querySelector", { nodeId: root.nodeId, selector });
+if (!nodeId) { console.error(`no element matches ${selector}`); process.exit(1); }
+const m = await cdp.send("CSS.getMatchedStylesForNode", { nodeId });
+
+console.log(`rules setting \`${prop}\` on ${selector}, weakest first:\n`);
+for (const r of m.matchedCSSRules || []) {
+  const d = (r.rule.style.cssProperties || []).find((p) => p.name === prop);
+  if (d) console.log(`  ${r.rule.selectorList.text.slice(0, 60).padEnd(62)} ${prop}:${String(d.value).padEnd(10)} layer=${(r.rule.layers || []).map((l) => l.text).join(">") || "(none)"}`);
+}
+console.log(`\ncomputed: ${await page.evaluate(([s, p]) => getComputedStyle(document.querySelector(s))[p], [selector, prop])}`);
+await browser.close();

--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ tumlive.service
 
 # osx
 .DS_Store
+
+# Scratch output from .claude/skills/local-testing (screenshot diffs)
+.shots/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,116 @@
+# AGENTS.md
+
+GoCast (TUM-Live) is a lecture streaming platform: a Go monolith that serves the web
+app and API, plus separate services that capture, transcode and deliver video.
+
+## Layout
+
+Five Go modules, joined by `go.work`:
+
+| Path | What |
+|---|---|
+| `.` | The main server — `cmd/tumlive` is the entrypoint |
+| `worker/` | Captures and transcodes streams |
+| `worker/edge/` | Edge delivery node |
+| `runner/` | Newer replacement for the worker |
+| `vod-service/` | Video-on-demand serving |
+
+Inside the main module: `model/` (GORM models), `dao/` (data access), `api/` (the REST
+API, v1), `apiv2/` (Protobuf/Connect API), `web/` (server-rendered pages), `tools/`
+(shared helpers), `mock_dao/` + `mock_tools/` (generated). `ingest/`, `rtmp-proxy/` and
+`voice-service/` are supporting services; `docs_v2/` is the Docusaurus site.
+
+## The two frontends — read this before touching UI
+
+The app is **mid-migration from server-rendered templates to a Vue SPA**, page by page.
+Both are live at once, and which one serves a given URL is a deliberate choice:
+
+- **`web/`** — Go templates (`web/template/*.gohtml`) with Alpine.js and TypeScript in
+  `web/ts/`, bundled by webpack. The legacy side.
+- **`frontend/`** — Vue 3 + Vite SPA, with Pinia and vue-router. Builds into `web/spa/`,
+  which is embedded into the Go binary.
+
+`spaRoutes` in [`web/router.go`](web/router.go) is the source of truth for which paths
+the SPA owns. Moving a page across means adding its path **both** there and in
+`frontend/src/router/index.ts` — the shell renders nothing if the client router doesn't
+know the route. `web/spa_test.go` covers the Go half of that contract.
+
+Consequence worth internalising: **if you don't build the SPA, every migrated route
+silently falls back to its old template.** You will be looking at the frontend being
+replaced and think it works.
+
+## Build and test
+
+```bash
+make test                            # go test -race ./... + frontend unit tests
+make lint                            # golangci-lint + web eslint + frontend typecheck
+npm --prefix frontend test           # vitest
+npm --prefix frontend run typecheck  # vue-tsc
+npm --prefix web run lint            # eslint (flat config; lints web/ts only, on purpose)
+```
+
+`npm ci` in `web/` is required to **compile the Go server at all** — `web/router.go`
+has `//go:embed node_modules`. It is not just about icons rendering.
+
+For running the app, browser testing, and visual regression, use the
+**`local-testing` skill** (`.claude/skills/local-testing/`). It has the database
+seeding, the asset build order, the fixture accounts and the screenshot-diff scripts.
+Don't reconstruct that from scratch.
+
+## Generated code is committed
+
+Regenerate deliberately; don't hand-edit the output.
+
+```bash
+make mocks                 # go generate ./... -> mock_dao/, mock_tools/
+./apiv2/generate.sh        # apiv2.proto -> Go server + docs
+make proto_es              # apiv2.proto -> frontend/src/gen (TypeScript client)
+go run cmd/modelGen/modelGen.go <ModelName>   # scaffolds a model + dao
+```
+
+The proto is one file, `apiv2/server/apiv2.proto`, and both sides generate from it.
+Change it and run both generators, or the Go and TypeScript halves drift.
+
+New API work belongs in `apiv2/` (Protobuf/Connect), not `api/`.
+
+## Database
+
+GORM `AutoMigrate` runs on boot from `cmd/tumlive/main.go`, so adding a field to a model
+is usually enough. Anything `AutoMigrate` can't express — backfills, renames, data
+fixes — goes in `dao/migrations/` as a dated file.
+
+`tum-live-starter.sql` is the development fixture, and the browser tests assert on its
+contents. Treat its users, courses and lectures as an API.
+
+## Conventions
+
+- **Conventional commits**, with a scope: `feat(apiv2):`, `fix(runner):`,
+  `perf(frontend):`, `chore(web):`. Branch names follow the same shape
+  (`fix/vod-after-early-end`, `feat/speedup-public-courses-rpc`).
+- `dev` is the default branch and what PRs target; there is no `main`. Follow
+  `.github/pull_request_template.md` — motivation, description, **steps for testing**,
+  and screenshots for UI changes.
+- Comments should explain *why*, especially where the code looks odd. This codebase
+  does that well; match it. Several comments exist specifically to stop someone
+  "fixing" a deliberate choice — leave those in place.
+- Dependencies are Renovate's job. `renovate.json` carries version holds with the
+  reason and the condition for removing each one; read it before pinning something by
+  hand.
+
+## Traps
+
+- **Tailwind 4 utilities are unlayered on purpose.** `web/assets/css/{main,home}.css`
+  compose the Tailwind entry by hand instead of `@import "tailwindcss"`, because
+  layered utilities lose to unlayered vendor CSS (video.js, fullcalendar, flatpickr,
+  nouislider) regardless of specificity or order. Restoring the plain import silently
+  breaks layout wherever a utility meets a vendor stylesheet. See the `local-testing`
+  skill.
+- **`go run cmd/tumlive/main.go` leaves a process `pkill -f` won't match** — it runs a
+  compiled binary from a temp path. Kill it by port.
+- The `ldap:` block in `config.yaml` stays commented out in development: with
+  `useForLogin`, every rejected password falls back to LDAP and hangs if the host
+  doesn't resolve.
+- Meilisearch connection errors on boot are expected locally; only search is affected.
+- `web/spa/` holds a tracked marker so `go:embed` resolves on a fresh checkout, which
+  is why the Vite build deliberately does **not** empty it; the `prebuild` script
+  clears stale hashed assets instead.


### PR DESCRIPTION
Writes down how to bring the stack up locally and how to prove a change in a browser, so the next person doesn't rediscover it.

The second half is the reason this exists. The Tailwind 4 regressions in #1949 — a 1920px video player forcing scrollbars, four admin pages 320px past the viewport, every line of text reflowed — were invisible to lint, unit tests, typecheck and all eleven CI jobs. They were only found by screenshotting each page against `dev` and diffing.

### Scripts

Three, runnable from anywhere in the tree:

- **`capture.mjs`** — logs in, shoots 14 pages in light and dark, and reports the two things a screenshot alone hides: horizontal overflow, and error pages. The 404 and permission templates render with **HTTP 200**, so a screenshot of one is indistinguishable from a pass. This bit me while writing the skill: `/schedule` isn't a route (`/admin` *is* the schedule page) and my first version cheerfully captured the 404 as a clean result.
- **`compare.mjs`** — pixel-diffs two runs, separating size mismatches (the layout moved) from colour drift.
- **`matched-rules.mjs`** — lists every rule setting a property *with its cascade layer*, which is what actually explains a wrong size when the utility class looks correct.

### What the prose records

The expensive lessons: layered utilities lose to unlayered vendor CSS regardless of specificity or order; a class that was dead in one major can come alive in the next (`min-w-screen`); default theme tokens move between majors (the font stack); utility scale names get reused at new values (`shadow-sm`, `rounded-sm`, `outline-none`) — and `@tailwindcss/upgrade` skips those codemods precisely when the new version is already installed.

Plus the mechanical traps: `npm ci` in `web/` is required to *compile* (`router.go` embeds `node_modules`), the SPA build is required or migrated routes silently fall back to their old templates, `make e2e_db` exists because three clocks have to agree on what day it is, the login field is the users table's `email` column, `@playwright/test` not `playwright`, and `go run` leaves a process that `pkill -f cmd/tumlive/main.go` does not match.

Every command and all three scripts were run against a live stack while writing this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
