### PR TITLE
fix(admin): make lecture hall creation work and the name editable

### DIFF
--- a/api/lecture_halls.go
+++ b/api/lecture_halls.go
@@ -59,12 +59,15 @@ type lectureHallRoutes struct {
 }
 
 type updateLectureHallReq struct {
-	StreamProtocol int    `json:"streamProtocol"`
-	CamIp          string `json:"camIp"`
-	CombIp         string `json:"combIp"`
-	PresIP         string `json:"presIp"`
-	CameraIp       string `json:"cameraIp"`
-	PwrCtrlIp      string `json:"pwrCtrlIp"`
+	// Name is a pointer so that a client that does not manage the name at all keeps
+	// the stored one, while a client that sends an empty one gets told off.
+	Name           *string `json:"name"`
+	StreamProtocol int     `json:"streamProtocol"`
+	CamIp          string  `json:"camIp"`
+	CombIp         string  `json:"combIp"`
+	PresIP         string  `json:"presIp"`
+	CameraIp       string  `json:"cameraIp"`
+	PwrCtrlIp      string  `json:"pwrCtrlIp"`
 }
 
 func (r lectureHallRoutes) updateLectureHall(c *gin.Context) {
@@ -97,13 +100,24 @@ func (r lectureHallRoutes) updateLectureHall(c *gin.Context) {
 		})
 		return
 	}
+	if req.Name != nil {
+		name := strings.TrimSpace(*req.Name)
+		if name == "" {
+			_ = c.Error(tools.RequestError{
+				Status:        http.StatusBadRequest,
+				CustomMessage: "name can not be empty",
+			})
+			return
+		}
+		lectureHall.Name = name
+	}
 	lectureHall.StreamProtocol = model.StreamProtocol(req.StreamProtocol)
 	logger.Debug("New stream protocol", "protocol", lectureHall.StreamProtocol)
-	lectureHall.CamIP = req.CamIp
-	lectureHall.CombIP = req.CombIp
-	lectureHall.PresIP = req.PresIP
-	lectureHall.CameraIP = req.CameraIp
-	lectureHall.PwrCtrlIp = req.PwrCtrlIp
+	lectureHall.CamIP = strings.TrimSpace(req.CamIp)
+	lectureHall.CombIP = strings.TrimSpace(req.CombIp)
+	lectureHall.PresIP = strings.TrimSpace(req.PresIP)
+	lectureHall.CameraIP = strings.TrimSpace(req.CameraIp)
+	lectureHall.PwrCtrlIp = strings.TrimSpace(req.PwrCtrlIp)
 	err = r.LectureHallsDao.SaveLectureHall(lectureHall)
 	if err != nil {
 		logger.Error("error while updating lecture hall", "err", err)
@@ -455,7 +469,15 @@ func (r lectureHallRoutes) createLectureHall(c *gin.Context) {
 		})
 		return
 	}
-	r.LectureHallsDao.CreateLectureHall(model.LectureHall{
+	req.trimSpace()
+	if req.Name == "" {
+		_ = c.Error(tools.RequestError{
+			Status:        http.StatusBadRequest,
+			CustomMessage: "name can not be empty",
+		})
+		return
+	}
+	lectureHall := model.LectureHall{
 		Name:           req.Name,
 		StreamProtocol: model.StreamProtocol(req.StreamProtocol),
 		CombIP:         req.CombIP,
@@ -463,7 +485,17 @@ func (r lectureHallRoutes) createLectureHall(c *gin.Context) {
 		CamIP:          req.CamIP,
 		CameraIP:       req.CameraIP,
 		PwrCtrlIp:      req.PwrCtrlIP,
-	})
+	}
+	if err := r.LectureHallsDao.CreateLectureHall(&lectureHall); err != nil {
+		logger.Error("can not create lecture hall", "err", err)
+		_ = c.Error(tools.RequestError{
+			Status:        http.StatusInternalServerError,
+			CustomMessage: "can not create lecture hall",
+			Err:           err,
+		})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"id": lectureHall.ID})
 }
 
 func (r lectureHallRoutes) fetchLHPresets(lh model.LectureHall) error {
@@ -483,11 +515,22 @@ func (r lectureHallRoutes) fetchLHPresets(lh model.LectureHall) error {
 type createLectureHallRequest struct {
 	Name           string `json:"name"`
 	StreamProtocol int    `json:"streamProtocol"` // 1 = rtmp, 2 = srt
-	CombIP         string `json:"combIP"`
-	PresIP         string `json:"presIP"`
-	CamIP          string `json:"camIP"`
-	CameraIP       string `json:"cameraIP"`
+	CombIP         string `json:"combIp"`
+	PresIP         string `json:"presIp"`
+	CamIP          string `json:"camIp"`
+	CameraIP       string `json:"cameraIp"`
 	PwrCtrlIP      string `json:"pwrCtrlIp"`
+}
+
+// trimSpace normalises the addresses so that a field left blank in the admin form is
+// stored as empty rather than as whitespace, which BeforeSave would reject.
+func (r *createLectureHallRequest) trimSpace() {
+	r.Name = strings.TrimSpace(r.Name)
+	r.CombIP = strings.TrimSpace(r.CombIP)
+	r.PresIP = strings.TrimSpace(r.PresIP)
+	r.CamIP = strings.TrimSpace(r.CamIP)
+	r.CameraIP = strings.TrimSpace(r.CameraIP)
+	r.PwrCtrlIP = strings.TrimSpace(r.PwrCtrlIP)
 }
 
 type setLectureHallRequest struct {

--- a/api/lecture_halls_test.go
+++ b/api/lecture_halls_test.go
@@ -88,6 +88,40 @@ func TestLectureHallsCRUD(t *testing.T) {
 				Middlewares:  testutils.GetMiddlewares(tools.ErrorHandler, testutils.TUMLiveContext(testutils.TUMLiveContextAdmin)),
 				ExpectedCode: http.StatusBadRequest,
 			},
+			"empty name": {
+				Router: func(r *gin.Engine) {
+					wrapper := dao.DaoWrapper{
+						LectureHallsDao: func() dao.LectureHallsDao {
+							lectureHallMock := mock_dao.NewMockLectureHallsDao(ctrl)
+							lectureHallMock.EXPECT().CreateLectureHall(gomock.Any()).Times(0)
+							return lectureHallMock
+						}(),
+					}
+					configGinLectureHallApiRouter(r, wrapper, newCamServiceMock(ctrl), "")
+				},
+				Middlewares:  testutils.GetMiddlewares(tools.ErrorHandler, testutils.TUMLiveContext(testutils.TUMLiveContextAdmin)),
+				Body:         createLectureHallRequest{Name: "  ", StreamProtocol: 1},
+				ExpectedCode: http.StatusBadRequest,
+			},
+			"can not create": {
+				Router: func(r *gin.Engine) {
+					wrapper := dao.DaoWrapper{
+						LectureHallsDao: func() dao.LectureHallsDao {
+							lectureHallMock := mock_dao.NewMockLectureHallsDao(ctrl)
+							lectureHallMock.
+								EXPECT().
+								CreateLectureHall(gomock.Any()).
+								Return(errors.New("")).
+								AnyTimes()
+							return lectureHallMock
+						}(),
+					}
+					configGinLectureHallApiRouter(r, wrapper, newCamServiceMock(ctrl), "")
+				},
+				Middlewares:  testutils.GetMiddlewares(tools.ErrorHandler, testutils.TUMLiveContext(testutils.TUMLiveContextAdmin)),
+				Body:         body,
+				ExpectedCode: http.StatusInternalServerError,
+			},
 			"success": {
 				Router: func(r *gin.Engine) {
 					wrapper := dao.DaoWrapper{
@@ -95,7 +129,7 @@ func TestLectureHallsCRUD(t *testing.T) {
 							lectureHallMock := mock_dao.NewMockLectureHallsDao(ctrl)
 							lectureHallMock.
 								EXPECT().
-								CreateLectureHall(gomock.Any()).AnyTimes()
+								CreateLectureHall(gomock.Any()).Return(nil).AnyTimes()
 							return lectureHallMock
 						}(),
 					}

--- a/dao/lecture_halls.go
+++ b/dao/lecture_halls.go
@@ -12,7 +12,7 @@ import (
 //go:generate go tool mockgen -source=lecture_halls.go -destination ../mock_dao/lecture_halls.go
 
 type LectureHallsDao interface {
-	CreateLectureHall(lectureHall model.LectureHall)
+	CreateLectureHall(lectureHall *model.LectureHall) error
 	SavePreset(preset model.CameraPreset) error
 	SaveLectureHallFullAssoc(lectureHall model.LectureHall)
 	SaveLectureHall(lectureHall model.LectureHall) error
@@ -51,8 +51,8 @@ func (d lectureHallsDao) GetLiveStateForPwrCtrl() ([]PwrCtrlLiveState, error) {
 	return result, err
 }
 
-func (d lectureHallsDao) CreateLectureHall(lectureHall model.LectureHall) {
-	DB.Create(&lectureHall)
+func (d lectureHallsDao) CreateLectureHall(lectureHall *model.LectureHall) error {
+	return DB.Create(lectureHall).Error
 }
 
 func (d lectureHallsDao) SavePreset(preset model.CameraPreset) error {

--- a/mock_dao/lecture_halls.go
+++ b/mock_dao/lecture_halls.go
@@ -42,9 +42,11 @@ func (m *MockLectureHallsDao) EXPECT() *MockLectureHallsDaoMockRecorder {
 }
 
 // CreateLectureHall mocks base method.
-func (m *MockLectureHallsDao) CreateLectureHall(lectureHall model.LectureHall) {
+func (m *MockLectureHallsDao) CreateLectureHall(lectureHall *model.LectureHall) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "CreateLectureHall", lectureHall)
+	ret := m.ctrl.Call(m, "CreateLectureHall", lectureHall)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // CreateLectureHall indicates an expected call of CreateLectureHall.

--- a/model/lecture_hall.go
+++ b/model/lecture_hall.go
@@ -78,9 +78,12 @@ func (l *LectureHall) ToDTO() *LectureHallDTO {
 
 // BeforeSave returns an error if either source is invalid.
 func (l *LectureHall) BeforeSave(*gorm.DB) error {
-	_, err := netip.ParseAddr(l.CameraIP)
-	if err != nil {
-		return fmt.Errorf("invalid camera IP address: %s", l.CameraIP)
+	// The Axis camera is optional - halls without one (VMP backed ones, for example)
+	// leave it empty - but an address that is set has to be a valid one.
+	if l.CameraIP != "" {
+		if _, err := netip.ParseAddr(l.CameraIP); err != nil {
+			return fmt.Errorf("invalid camera IP address: %s", l.CameraIP)
+		}
 	}
 	u, err := url.Parse(l.CombIP)
 	if err != nil {

--- a/model/lecture_hall_test.go
+++ b/model/lecture_hall_test.go
@@ -29,6 +29,18 @@ func TestBeforeSaveLectureHall(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			// A hall without an Axis camera - VMP backed ones, for example - is valid.
+			l: LectureHall{
+				CameraIP: "",
+				CombIP:   "rtsp://0.0.0.0/comb",
+			},
+			expected: LectureHall{
+				CameraIP: "",
+				CombIP:   "rtsp://0.0.0.0/comb",
+			},
+			wantErr: false,
+		},
+		{
 			l: LectureHall{
 				CameraIP: "127.0.0.1",
 				CamIP:    "somehost/malicious\" && stuff",

--- a/web/assets/css/main.css
+++ b/web/assets/css/main.css
@@ -42,6 +42,18 @@
     @apply p-2 cursor-pointer rounded shadow-xs text-center text-gray-900 bg-white border border-gray-300 focus:outline-hidden hover:bg-gray-100 focus:ring-4 focus:ring-gray-200 font-bold rounded-lg text-sm px-5 py-2.5 dark:bg-gray-800 dark:text-white dark:border-gray-600 dark:hover:bg-gray-700 dark:hover:border-gray-600 dark:focus:ring-gray-700;
 }
 
+/*
+ * The call-to-action button. `.primary` cannot do this job next to `.btn`: it lives in
+ * the components layer, and a layered rule loses to an unlayered one no matter the
+ * specificity, so `btn primary` renders as a plain white button.
+ */
+@utility btn-primary {
+    @apply btn border-transparent bg-blue-500 text-white hover:bg-blue-600 hover:border-transparent
+        dark:bg-indigo-600 dark:text-white dark:border-transparent dark:hover:bg-indigo-800 dark:hover:border-transparent
+        disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-500 disabled:hover:bg-gray-200
+        dark:disabled:bg-gray-700 dark:disabled:text-gray-400 dark:disabled:hover:bg-gray-700;
+}
+
 @utility text-3 {
     @apply text-gray-800 dark:text-gray-200;
 }

--- a/web/template/admin/admin_tabs/create-lecture_halls.gohtml
+++ b/web/template/admin/admin_tabs/create-lecture_halls.gohtml
@@ -1,68 +1,121 @@
 {{define "createLectureHalls"}}
-<div x-data="{showSuccess: false}" class="">
-    <div class="alerts fixed w-fit left-0 right-0 mx-auto top-3 z-50">
-        <div x-show="showSuccess"
-            class="flex success bg-green-400 border border-green-600 pl-3 pr-3 pt-2 pb-2 rounded-lg shadow-md">
-            <span class="text-sm font-semibold text-slate-100 my-auto">
-                &#10003; Added lecture hall successfully.
-            </span>
-        </div>
-    </div>
-    <div
-        class="mx-auto w-4/5 my-10 shadow rounded-lg border bg-white dark:shadow-0 dark:border-gray-800 dark:bg-secondary-light">
-        <div class="border-b py-2 px-5 dark:border-gray-800">
-            <h6 class="text-3 font-bold">New Lecture-Hall</h6>
-        </div>
-        <form x-data="{name:'', streamProtocol: 1, combIP:'', presIP:'', camIP:'',cameraIp:'', pwrCtrlIp:''}" @submit.prevent="
-                    success = await admin.createLectureHall(name, parseInt(streamProtocol), combIP, presIP, camIP, cameraIp, pwrCtrlIp);
-                    setTimeout(() => {window.location = '/admin/lectureHalls';}, 2000);" class="grid gap-3 px-5 py-4 ">
-            <div class="text-sm">
-                <label for="name" class="block text-5">Name</label>
-                <input type="text" x-model="name" id="lh-form-name" placeholder="FMI_HS1" autofocus="" required
-                    class="tl-input mt-3" />
-            </div>
-            <div class="text-sm flex flex-row gap-3">
-                <span class="block text-5">Protocol</span>
-                <div class="flex flex-row gap-1">
-                    <input type="radio" x-model="streamProtocol" value=1 id="lh-form-stream-rtsp"
-                        class="tl-radio" />
-                    <label class="text-sm text-5" for="lh-form-stream-rtsp">rtsp</label>
-                    <input type="radio" x-model="streamProtocol" value=2 id="lh-form-stream-srt"
-                           class="tl-radio" />
-                    <label class="text-sm text-5" for="lh-form-stream-srt">srt</label>
+    <form class="form-container"
+          x-data="{
+              name: '',
+              streamProtocol: 1,
+              presIp: '',
+              camIp: '',
+              combIp: '',
+              cameraIp: '',
+              pwrCtrlIp: '',
+              saving: false,
+              error: '',
+              async submit() {
+                  this.error = '';
+                  this.saving = true;
+                  const res = await admin.createLectureHall(this.name, parseInt(this.streamProtocol),
+                      this.combIp, this.presIp, this.camIp, this.cameraIp, this.pwrCtrlIp);
+                  this.saving = false;
+                  if (!res.ok) {
+                      this.error = res.error;
+                      return;
+                  }
+                  window.location = '/admin/lectureHalls';
+              },
+          }"
+          @submit.prevent="submit()">
+        <h2 class="form-container-title">New Lecture Hall</h2>
+
+        <div class="form-container-body">
+            <div x-cloak x-show="error"
+                 class="flex items-start gap-2 rounded-lg border border-red-300 bg-red-50 px-3 py-2 dark:border-red-900 dark:bg-red-950">
+                <i class="fa fa-circle-exclamation mt-0.5 text-red-600 dark:text-red-400"></i>
+                <div>
+                    <p class="text-sm font-semibold text-red-700 dark:text-red-300">
+                        Could not create the lecture hall
+                    </p>
+                    <p class="text-sm text-red-700 dark:text-red-300" x-text="error"></p>
                 </div>
             </div>
-            <div class="text-sm">
-                <label for="name" class="block text-5">Presentation</label>
-                <input type="text" x-model="presIP" id="lh-form-pres" placeholder="0.0.0.0" autofocus="" required
-                    class="tl-input mt-3" />
+
+            <div class="grid gap-4 sm:grid-cols-2">
+                <div>
+                    <label for="lh-form-name">Name <span class="text-red-600 dark:text-red-400">*</span></label>
+                    <input id="lh-form-name" type="text" x-model="name" placeholder="FMI_HS1" autofocus required
+                           class="tl-input mt-1"/>
+                    <p class="mt-1 text-xs text-5">As the hall is named in SMP, e.g. <code>room_00_13_009A</code>.</p>
+                </div>
+                <div>
+                    <span class="text-sm text-5 font-light">Stream protocol</span>
+                    <div class="mt-1 flex h-12 items-center gap-4">
+                        <div class="flex items-center gap-2">
+                            <input type="radio" id="lh-form-stream-rtsp" name="lh-form-stream" value="1"
+                                   x-model="streamProtocol" class="tl-radio"/>
+                            <label for="lh-form-stream-rtsp" class="text-sm text-5">rtsp</label>
+                        </div>
+                        <div class="flex items-center gap-2">
+                            <input type="radio" id="lh-form-stream-srt" name="lh-form-stream" value="2"
+                                   x-model="streamProtocol" class="tl-radio"/>
+                            <label for="lh-form-stream-srt" class="text-sm text-5">srt</label>
+                        </div>
+                    </div>
+                </div>
             </div>
-            <div class="text-sm">
-                <label for="name" class="block text-5">Camera</label>
-                <input type="text" x-model="camIP" id="lh-form-cam-ip" placeholder="0.0.0.0" autofocus="" required
-                    class="tl-input mt-3" />
+
+            <div class="border-t pt-3 dark:border-gray-800">
+                <h2>Sources</h2>
+                <p class="text-xs text-5">
+                    Stream URLs the worker pulls from. Fill in the ones this hall actually offers - a hall with
+                    only a combined feed leaves presentation and camera empty.
+                </p>
+                <div class="mt-3 grid gap-4 sm:grid-cols-3">
+                    <div>
+                        <label for="lh-form-pres">Presentation</label>
+                        <input id="lh-form-pres" type="text" x-model="presIp" placeholder="rtsp://0.0.0.0/pres"
+                               class="tl-input mt-1"/>
+                    </div>
+                    <div>
+                        <label for="lh-form-cam-ip">Camera</label>
+                        <input id="lh-form-cam-ip" type="text" x-model="camIp" placeholder="rtsp://0.0.0.0/cam"
+                               class="tl-input mt-1"/>
+                    </div>
+                    <div>
+                        <label for="lh-form-comb-ip">Combined</label>
+                        <input id="lh-form-comb-ip" type="text" x-model="combIp" placeholder="rtsp://0.0.0.0/comb"
+                               class="tl-input mt-1"/>
+                    </div>
+                </div>
             </div>
-            <div class="text-sm">
-                <label for="name" class="block text-5">Combined</label>
-                <input type="text" x-model="combIP" id="lh-form-comb-ip" placeholder="0.0.0.0" autofocus="" required
-                    class="tl-input mt-3" />
+
+            <div class="border-t pt-3 dark:border-gray-800">
+                <h2>Hardware <span class="font-normal text-5">- optional</span></h2>
+                <p class="text-xs text-5">
+                    Only for halls with the physical devices attached. VMP backed halls have neither.
+                </p>
+                <div class="mt-3 grid gap-4 sm:grid-cols-2">
+                    <div>
+                        <label for="lh-form-camera-ip">Axis camera</label>
+                        <input id="lh-form-camera-ip" type="text" x-model="cameraIp" placeholder="10.0.0.1"
+                               class="tl-input mt-1"/>
+                        <p class="mt-1 text-xs text-5">IP of the camera itself - enables presets. Leave empty if
+                            there is none.</p>
+                    </div>
+                    <div>
+                        <label for="lh-form-pwrctrl-ip">Anel PWR-Ctrl</label>
+                        <input id="lh-form-pwrctrl-ip" type="text" x-model="pwrCtrlIp" placeholder="10.0.0.2"
+                               class="tl-input mt-1"/>
+                        <p class="mt-1 text-xs text-5">Drives the red live light. Leave empty if there is none.</p>
+                    </div>
+                </div>
             </div>
-            <div class="text-sm">
-                <label for="name" class="block text-5">Axis Cam</label>
-                <input type="text" x-model="cameraIp" id="lh-form-camera-ip" placeholder="0.0.0.0" autofocus="" required
-                    class="tl-input mt-3" />
-            </div>
-            <div class="text-sm">
-                <label for="name" class="block text-5">Anel PWR-Ctrl</label>
-                <input type="text" x-model="pwrCtrlIp" id="lh-form-pwrctrl-ip" placeholder="0.0.0.0" autofocus=""
-                    required
-                    class="tl-input mt-3" />
-            </div>
-            <button type="submit"
-                class="block bg-blue-500 text-center px-3 py-1 mt-3 rounded w-full dark:bg-indigo-600">
-                <span class="text-white uppercase text-sm font-semibold">Create</span>
+        </div>
+
+        <div class="form-container-footer flex items-center justify-end gap-2">
+            <a href="/admin/lectureHalls" class="btn">Cancel</a>
+            <button type="submit" class="btn-primary" :disabled="saving || !name.trim()">
+                <span x-show="!saving">Create</span>
+                <span x-cloak x-show="saving">Creating&hellip;</span>
             </button>
-        </form>
-    </div>
-</div>
+        </div>
+    </form>
 {{end}}

--- a/web/template/admin/admin_tabs/lecture_halls.gohtml
+++ b/web/template/admin/admin_tabs/lecture_halls.gohtml
@@ -1,129 +1,203 @@
 {{define "lectureHalls"}}
     {{- /*gotype: github.com/TUM-Dev/gocast/[]model.LectureHall*/ -}}
-    <a href="/admin/lectureHalls/new" class="mx-auto w-4/5 mt-8 btn primary block">
-        &#43; New Lecture Hall
-    </a>
+    <div x-data="{filter: '', matches(name) { return name.toLowerCase().includes(this.filter.trim().toLowerCase()) }}">
+        <div class="mx-auto w-full md:w-4/5 mt-8 flex flex-wrap items-center gap-3">
+            <h1 class="text-2xl text-1 font-medium mr-auto">
+                Lecture Halls
+                <span class="text-base font-normal text-5">({{len .}})</span>
+            </h1>
+            {{/* .tl-input carries w-full unlayered, so the width has to come from the parent. */}}
+            <div class="w-64 shrink-0">
+                <input type="search" x-model="filter" placeholder="Filter by name"
+                       aria-label="Filter lecture halls by name" class="tl-input"/>
+            </div>
+            <a href="/admin/lectureHalls/new" class="btn-primary">&#43; New Lecture Hall</a>
+        </div>
 
-    {{range $lectureHall := .}}
-        <div id="{{$lectureHall.Model.ID}}" x-data="{
-            changed:false,
-            saved:false,
-            savingFailed:false,
-            name: '{{$lectureHall.Name}}',
-            streamProtocol{{$lectureHall.Model.ID}}: {{$lectureHall.StreamProtocol}},
-            presIp: '{{$lectureHall.PresIP}}',
-            camIp: '{{$lectureHall.CamIP}}',
-            combIp: '{{$lectureHall.CombIP}}',
-            cameraIp: '{{$lectureHall.CameraIP}}',
-            pwrCtrlIp: '{{$lectureHall.PwrCtrlIp}}',
-            id: '{{$lectureHall.ID}}',}"
-             :class="window.location.hash.substr(1)===`${id}`?'dark:border-blue-500 border-blue-500':'dark:border-secondary-light'"
-             class="form-container">
+        {{range $lectureHall := .}}
+            <div x-show="matches('{{$lectureHall.Name}}')">
+                <form id="{{$lectureHall.Model.ID}}"
+                      x-data="{
+                          id: {{$lectureHall.Model.ID}},
+                          name: '{{$lectureHall.Name}}',
+                          streamProtocol: '{{$lectureHall.StreamProtocol}}',
+                          presIp: '{{$lectureHall.PresIP}}',
+                          camIp: '{{$lectureHall.CamIP}}',
+                          combIp: '{{$lectureHall.CombIP}}',
+                          cameraIp: '{{$lectureHall.CameraIP}}',
+                          pwrCtrlIp: '{{$lectureHall.PwrCtrlIp}}',
+                          saving: false,
+                          saved: false,
+                          error: '',
+                          fields: ['name', 'streamProtocol', 'presIp', 'camIp', 'combIp', 'cameraIp', 'pwrCtrlIp'],
+                          stored: {},
+                          init() { this.stored = this.snapshot() },
+                          snapshot() { return Object.fromEntries(this.fields.map(f => [f, this[f]])) },
+                          get changed() { return this.fields.some(f => this[f] !== this.stored[f]) },
+                          reset() { Object.assign(this, this.stored); this.error = '' },
+                          async save() {
+                              this.error = '';
+                              this.saved = false;
+                              this.saving = true;
+                              const pending = this.snapshot();
+                              const res = await admin.updateLectureHall(this.id, this.name,
+                                  parseInt(this.streamProtocol), this.combIp, this.presIp, this.camIp,
+                                  this.cameraIp, this.pwrCtrlIp);
+                              this.saving = false;
+                              if (!res.ok) {
+                                  this.error = res.error;
+                                  return;
+                              }
+                              this.stored = pending;
+                              this.saved = true;
+                              setTimeout(() => { this.saved = false }, 3000);
+                          },
+                      }"
+                      @submit.prevent="save()"
+                      :class="window.location.hash.substr(1) === `${id}` ? 'dark:border-blue-500 border-blue-500' : 'dark:border-secondary-light'"
+                      class="form-container">
 
-            <h2 class="form-container-title">
-                {{$lectureHall.Name}}
-            </h2>
+                    <div class="form-container-title flex flex-wrap items-center gap-2">
+                        <span x-text="stored.name" class="mr-auto">{{$lectureHall.Name}}</span>
+                        <span x-cloak x-show="changed"
+                              class="flex items-center px-2 py-1 text-xs font-light text-3 border border-amber-200 bg-amber-200/50 rounded-full">
+                            <i class="fa fa-triangle-exclamation mr-1"></i> Unsaved changes
+                        </span>
+                        <span x-cloak x-show="saved" x-transition.delay.200ms
+                              class="flex items-center px-2 py-1 text-xs font-light text-green-700 dark:text-green-400 border border-green-300 bg-green-100/50 dark:border-green-900 dark:bg-green-950 rounded-full">
+                            <i class="fa fa-check mr-1"></i> Saved
+                        </span>
+                        <span class="text-xs font-normal text-5">#{{$lectureHall.Model.ID}}</span>
+                    </div>
 
-            <div class="form-container-body grid grid-cols-3 gap-3 p-4">
-                <h2 class="text-sm text-4 col-span-full">Sources</h2>
-                <ul class="grid gap-4 md:grid-cols-3 lg:grid-cols-6 col-span-full">
-                    <li>
-                        <span class="text-sm text-5">Protocol</span>
-                        <div class="flex flex-col">
+                    <div class="form-container-body">
+                        <div x-cloak x-show="error"
+                             class="flex items-start gap-2 rounded-lg border border-red-300 bg-red-50 px-3 py-2 dark:border-red-900 dark:bg-red-950">
+                            <i class="fa fa-circle-exclamation mt-0.5 text-red-600 dark:text-red-400"></i>
                             <div>
-                                <input type="radio" @change="changed=true" x-model="streamProtocol{{$lectureHall.Model.ID}}"
-                                       value=1 id="rtsp{{$lectureHall.Model.ID}}">
-                                <label class="text-sm text-5" for="rtsp{{$lectureHall.Model.ID}}">rtsp</label>
-                            </div>
-                            <div>
-                                <input type="radio" @change="changed=true" x-model="streamProtocol{{$lectureHall.Model.ID}}"
-                                       value=2 id="srt{{$lectureHall.Model.ID}}">
-                                <label class="text-sm text-5" for="srt{{$lectureHall.Model.ID}}">srt</label>
+                                <p class="text-sm font-semibold text-red-700 dark:text-red-300">
+                                    Could not save this lecture hall
+                                </p>
+                                <p class="text-sm text-red-700 dark:text-red-300" x-text="error"></p>
                             </div>
                         </div>
-                    </li>
-                    <li>
-                        <span class="text-sm text-5">Presentation</span>
-                        <input class="tl-input" type="text" @keyup="changed=true " x-model="presIp"
-                               value="{{if $lectureHall.PresIP}}{{$lectureHall.PresIP}}{{end}}">
-                    </li>
-                    <li>
-                        <span class="text-sm text-5">Camera</span>
-                        <input class="tl-input" type="text" @keyup="changed=true " x-model="camIp"
-                               value="{{if $lectureHall.CamIP}}{{$lectureHall.CamIP}}{{end}}">
-                    </li>
-                    <li>
-                        <span class="text-sm text-5">Combined</span>
-                        <input class="tl-input" type="text" @keyup="changed=true " x-model="combIp"
-                               value="{{if $lectureHall.CombIP}}{{$lectureHall.CombIP}}{{end}}">
-                    </li>
-                    <li>
-                        <span class="text-sm text-5">Axis Cam</span>
-                        <input class="tl-input" type="text" @keyup="changed=true" x-model="cameraIp"
-                               value="{{if $lectureHall.CameraIP}}{{$lectureHall.CameraIP}}{{end}}">
-                    </li>
-                    <li>
-                        <span class="text-sm text-5">Anel PWR-Ctrl</span>
-                        <input class="tl-input" type="text" @keyup="changed=true" x-model="pwrCtrlIp"
-                               value="{{if $lectureHall.PwrCtrlIp}}{{$lectureHall.PwrCtrlIp}}{{end}}">
-                    </li>
-                </ul>
-                {{if $lectureHall.CameraIP}}
-                    <h2 class="col-span-full">Presets</h2>
-                    <div class="flex flex-row col-span-full">
-                        <div class="flex align-middle overflow-x-scroll">
-                            <div class="w-full scrollbarThin">
-                                <div class="flex flex-row gap-x-2">
-                                    {{range $preset := $lectureHall.CameraPresets}}
-                                        <div x-data="{defaultPreset: {{$preset.IsDefault}}, lectureHallID: {{$preset.LectureHallID}}}"
-                                             @resetdefaults.window="e => {if(e.detail === lectureHallID){defaultPreset = false}}"
-                                             style="min-width: 150px" class="text-center text-sm text-5 relative group"
-                                        >
-                                            <img id="presetImage{{$preset.LectureHallID}}-{{$preset.PresetID}}"
-                                                 src="/public/{{if $preset.Image}}{{$preset.Image}}{{else}}noPreset.jpg{{end}}"
-                                                 alt="prev" width="150px"
-                                                 class="tl-presetimage">
-                                            <i @click="admin.setDefaultPreset({{$preset.LectureHallID}}, {{$preset.PresetID}}).then((r) => {if(r){$dispatch('resetdefaults', lectureHallID);defaultPreset=true}})"
-                                               title="Set default" :class="!defaultPreset && 'opacity-0'"
-                                               class="group-hover:opacity-100 absolute top-1 left-1 p-1 rounded text-white bg-blue-600 fas fa-check"></i>
-                                            <i onclick="admin.takeSnapshot({{$preset.LectureHallID}}, {{$preset.PresetID}})"
-                                               title="Take new snapshot"
-                                               class="opacity-0 group-hover:opacity-100 absolute top-1 right-1 p-1 rounded text-white bg-indigo-500 fas fa-sync"></i>
-                                            <span title="{{$preset.Name}}" class="truncate block my-2"
-                                            >{{$preset.Name}}</span>
-                                        </div>
-                                    {{end}}
+
+                        <div class="grid gap-4 sm:grid-cols-2">
+                            <div>
+                                <label for="lh-{{$lectureHall.Model.ID}}-name">Name</label>
+                                <input id="lh-{{$lectureHall.Model.ID}}-name" type="text" x-model="name" required
+                                       class="tl-input mt-1"/>
+                            </div>
+                            <div>
+                                <span class="text-sm text-5 font-light">Stream protocol</span>
+                                <div class="mt-1 flex h-12 items-center gap-4">
+                                    <div class="flex items-center gap-2">
+                                        <input type="radio" name="lh-{{$lectureHall.Model.ID}}-protocol" value="1"
+                                               x-model="streamProtocol" id="rtsp{{$lectureHall.Model.ID}}"/>
+                                        <label class="text-sm text-5" for="rtsp{{$lectureHall.Model.ID}}">rtsp</label>
+                                    </div>
+                                    <div class="flex items-center gap-2">
+                                        <input type="radio" name="lh-{{$lectureHall.Model.ID}}-protocol" value="2"
+                                               x-model="streamProtocol" id="srt{{$lectureHall.Model.ID}}"/>
+                                        <label class="text-sm text-5" for="srt{{$lectureHall.Model.ID}}">srt</label>
+                                    </div>
                                 </div>
                             </div>
                         </div>
+
+                        <div class="border-t pt-3 dark:border-gray-800">
+                            <h2>Sources</h2>
+                            <p class="text-xs text-5">Stream URLs the worker pulls from. Leave a source empty if the
+                                hall does not offer it.</p>
+                            <div class="mt-3 grid gap-4 sm:grid-cols-3">
+                                <div>
+                                    <label for="lh-{{$lectureHall.Model.ID}}-pres">Presentation</label>
+                                    <input id="lh-{{$lectureHall.Model.ID}}-pres" type="text" x-model="presIp"
+                                           placeholder="rtsp://0.0.0.0/pres" class="tl-input mt-1"/>
+                                </div>
+                                <div>
+                                    <label for="lh-{{$lectureHall.Model.ID}}-cam">Camera</label>
+                                    <input id="lh-{{$lectureHall.Model.ID}}-cam" type="text" x-model="camIp"
+                                           placeholder="rtsp://0.0.0.0/cam" class="tl-input mt-1"/>
+                                </div>
+                                <div>
+                                    <label for="lh-{{$lectureHall.Model.ID}}-comb">Combined</label>
+                                    <input id="lh-{{$lectureHall.Model.ID}}-comb" type="text" x-model="combIp"
+                                           placeholder="rtsp://0.0.0.0/comb" class="tl-input mt-1"/>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="border-t pt-3 dark:border-gray-800">
+                            <h2>Hardware <span class="font-normal text-5">- optional</span></h2>
+                            <p class="text-xs text-5">Only for halls with the physical devices attached. VMP backed
+                                halls have neither.</p>
+                            <div class="mt-3 grid gap-4 sm:grid-cols-2">
+                                <div>
+                                    <label for="lh-{{$lectureHall.Model.ID}}-camera">Axis camera</label>
+                                    <input id="lh-{{$lectureHall.Model.ID}}-camera" type="text" x-model="cameraIp"
+                                           placeholder="10.0.0.1" class="tl-input mt-1"/>
+                                </div>
+                                <div>
+                                    <label for="lh-{{$lectureHall.Model.ID}}-pwrctrl">Anel PWR-Ctrl</label>
+                                    <input id="lh-{{$lectureHall.Model.ID}}-pwrctrl" type="text" x-model="pwrCtrlIp"
+                                           placeholder="10.0.0.2" class="tl-input mt-1"/>
+                                </div>
+                            </div>
+                        </div>
+
+                        {{if $lectureHall.CameraIP}}
+                            <div class="border-t pt-3 dark:border-gray-800">
+                                <div class="flex items-center gap-2">
+                                    <h2 class="mr-auto">Camera presets</h2>
+                                    <button type="button" x-data="{loading: false}" title="Refresh list"
+                                            class="btn py-1 text-xs"
+                                            @click="loading = true; fetch('/api/refreshLectureHallPresets/{{$lectureHall.Model.ID}}').then(d => d.status == 200 ? window.location.reload() : alert('there was an error'))">
+                                        <i class="fa fa-sync mr-1" :class="loading && 'fa-spin'"></i> Reload presets
+                                    </button>
+                                </div>
+                                {{if $lectureHall.CameraPresets}}
+                                    <div class="mt-3 overflow-x-auto scrollbarThin">
+                                        <div class="flex flex-row gap-x-2">
+                                            {{range $preset := $lectureHall.CameraPresets}}
+                                                <div x-data="{defaultPreset: {{$preset.IsDefault}}, lectureHallID: {{$preset.LectureHallID}}}"
+                                                     @resetdefaults.window="e => {if(e.detail === lectureHallID){defaultPreset = false}}"
+                                                     style="min-width: 150px" class="text-center text-sm text-5 relative group">
+                                                    <img id="presetImage{{$preset.LectureHallID}}-{{$preset.PresetID}}"
+                                                         src="/public/{{if $preset.Image}}{{$preset.Image}}{{else}}noPreset.jpg{{end}}"
+                                                         alt="prev" width="150px" class="tl-presetimage">
+                                                    <i @click="admin.setDefaultPreset({{$preset.LectureHallID}}, {{$preset.PresetID}}).then((r) => {if(r){$dispatch('resetdefaults', lectureHallID);defaultPreset=true}})"
+                                                       title="Set default" :class="!defaultPreset && 'opacity-0'"
+                                                       class="group-hover:opacity-100 absolute top-1 left-1 p-1 rounded text-white bg-blue-600 fas fa-check"></i>
+                                                    <i onclick="admin.takeSnapshot({{$preset.LectureHallID}}, {{$preset.PresetID}})"
+                                                       title="Take new snapshot"
+                                                       class="opacity-0 group-hover:opacity-100 absolute top-1 right-1 p-1 rounded text-white bg-indigo-500 fas fa-sync"></i>
+                                                    <span title="{{$preset.Name}}" class="truncate block my-2">{{$preset.Name}}</span>
+                                                </div>
+                                            {{end}}
+                                        </div>
+                                    </div>
+                                {{else}}
+                                    <p class="mt-3 text-sm text-5">No presets fetched from this camera yet.</p>
+                                {{end}}
+                            </div>
+                        {{end}}
                     </div>
-                {{end}}
-                <span x-show="saved" x-transition.delay.200ms class="mr-4 text-green-400 mb-6">
-            Saved Successfully
-        </span>
-                <span x-show="savingFailed" x-transition.delay.200ms class="mr-4 text-red-400 mb-6">
-            Error updating lecture hall
-        </span>
-                <button class="btn" @click="fetch('/api/lectureHall/'+id, {method: 'PUT', headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify({streamProtocol: parseInt(streamProtocol{{$lectureHall.Model.ID}}), presIp: presIp, camIp: camIp, combIp: combIp, cameraIp: cameraIp, pwrCtrlIp: pwrCtrlIp})})
-                                    .then(r => {
-                                        saved = r.status === 200
-                                        savingFailed = !saved
-                                    });timeout = setTimeout(() => { saved = false; savingFailed = false; }, 3000)"
-                        :disabled="!changed" class="btn">
-                    Save
-                </button>
-                {{if $lectureHall.CameraIP}}
-                    <button x-data="{loading:false}" title="Refresh list" class="btn"
-                            @click="loading=true;fetch('/api/refreshLectureHallPresets/{{$lectureHall.Model.ID}}').then(d=>d.status==200?window.location.reload():alert('there was an error'))">
-                        Reload Presets
-                    </button>
-                {{end}}
-                <button class="btn" title="Delete Lecture Hall"
-                        onclick="admin.deleteLectureHall({{$lectureHall.Model.ID}})">
-                    Delete
-                </button>
+
+                    <div class="form-container-footer flex flex-wrap items-center gap-2">
+                        <button type="button" class="btn text-red-600 dark:text-red-400 mr-auto"
+                                title="Delete Lecture Hall"
+                                onclick="admin.deleteLectureHall({{$lectureHall.Model.ID}})">
+                            Delete
+                        </button>
+                        <button type="button" class="btn" @click="reset()" x-cloak x-show="changed">Reset</button>
+                        <button type="submit" class="btn-primary" :disabled="!changed || saving || !name.trim()">
+                            <span x-show="!saving">Save</span>
+                            <span x-cloak x-show="saving">Saving&hellip;</span>
+                        </button>
+                    </div>
+                </form>
             </div>
-        </div>
-    {{end}}
+        {{end}}
+    </div>
 {{end}}

--- a/web/ts/admin.ts
+++ b/web/ts/admin.ts
@@ -92,26 +92,67 @@ export class AdminUserList {
     }
 }
 
+export type LectureHallResult = { ok: boolean; error?: string };
+
 export async function createLectureHall(
     name: string,
     streamProtocol: number,
-    combIP: string,
-    presIP: string,
-    camIP: string,
+    combIp: string,
+    presIp: string,
+    camIp: string,
     cameraIp: string,
     pwrCtrlIp: string,
-) {
-    return postData("/api/createLectureHall", {
+): Promise<LectureHallResult> {
+    const res = await postData("/api/createLectureHall", {
         name,
         streamProtocol,
-        presIP,
-        camIP,
-        combIP,
+        presIp,
+        camIp,
+        combIp,
         cameraIp,
         pwrCtrlIp,
-    }).then((e) => {
-        return e.status === StatusCodes.OK;
     });
+    return toLectureHallResult(res);
+}
+
+export async function updateLectureHall(
+    id: number,
+    name: string,
+    streamProtocol: number,
+    combIp: string,
+    presIp: string,
+    camIp: string,
+    cameraIp: string,
+    pwrCtrlIp: string,
+): Promise<LectureHallResult> {
+    const res = await fetch(`/api/lectureHall/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, streamProtocol, presIp, camIp, combIp, cameraIp, pwrCtrlIp }),
+    });
+    return toLectureHallResult(res);
+}
+
+/**
+ * Turns a lecture hall API response into a result carrying the server's own message,
+ * so the form can say why a save was rejected instead of just that it was.
+ */
+async function toLectureHallResult(res: Response): Promise<LectureHallResult> {
+    if (res.status === StatusCodes.OK) {
+        return { ok: true };
+    }
+    let error = `Request failed with status ${res.status}.`;
+    try {
+        const body = await res.json();
+        if (typeof body === "string") {
+            error = body;
+        } else if (body?.message) {
+            error = body.error ? `${body.message}: ${body.error}` : body.message;
+        }
+    } catch {
+        // No JSON body - keep the status based message.
+    }
+    return { ok: false, error };
 }
 
 export async function deleteLectureHall(lectureHallID: number) {


### PR DESCRIPTION
`/admin/lectureHalls` had a handful of problems that all traced back to one root cause.

## Creating a hall silently did nothing

`LectureHall.BeforeSave` required `CameraIP` to parse as an IP address, so GORM rejected any hall without an Axis camera. `CreateLectureHall` had no error return and discarded the result, and the handler replied `200` regardless. Reproduced against a local instance before the fix:

```
POST /api/createLectureHall {"name":"VMP_HS1","cameraIp":"", ...}  ->  HTTP 200, no row
```

The form marking every field `required` was papering over this — which is also why halls that genuinely have no Axis camera or Anel PWR-Ctrl, VMP backed ones in particular, could not be entered at all.

## Changes

**Backend**
- Validate `CameraIP` only when one is set; a value that is present still has to be a real address.
- `CreateLectureHall` returns its error and takes a pointer, so the caller also gets the new ID. Mock regenerated.
- Create rejects a blank name with `400`, reports a failed insert as `500` with the reason, and trims whitespace that `BeforeSave` would otherwise reject.
- Update accepts a `name` so halls can be renamed. It is a `*string`: a client that doesn't send one keeps the stored name, an explicitly empty one is refused.

**Frontend**
- Both calls return `{ok, error}` carrying the server's own message; the edit request moved out of the template into `admin.ts`.
- Both templates reworked: only the name is required, fields grouped into **Sources** and an optional **Hardware** section with hints, failures shown in a banner naming the cause, the name editable, the list filterable, and each card tracks unsaved/saved state against its stored values — so undoing an edit disables Save again.

**One thing worth a look:** `btn primary` never applied. `@utility btn` lands in Tailwind's `utilities` layer and `.primary` in `components`, and a layered rule loses to an unlayered one regardless of specificity, so those buttons rendered plain white. This adds a `btn-primary` utility for the call to action. Other pages still using `btn primary` have the same latent issue; left alone as out of scope.

## Testing

`go test -race ./...`, eslint and `vue-tsc` all clean. Driven in a real browser against a local instance with the starter fixture:

- creating a hall with only a name and a combined URL succeeds
- a bad Axis IP surfaces `can not create lecture hall: invalid camera IP address: nonsense` in the banner
- renaming persists and updates the card title; Save re-disables after saving
- the presets block still renders for a hall with a camera
- no JS errors, no horizontal overflow at 1440px or 420px, light and dark both verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)
