### PR TITLE
test: cover model, tools and the camera drivers

### DIFF
--- a/model/stream_test.go
+++ b/model/stream_test.go
@@ -1,0 +1,1058 @@
+package model
+
+import (
+	"database/sql"
+	"encoding/json"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// streamAt builds a stream spanning [now+startOffset, now+endOffset). Every time
+// assertion below is relative so the suite cannot rot or fail on a given date.
+func streamAt(startOffset, endOffset time.Duration) Stream {
+	now := time.Now()
+	return Stream{Start: now.Add(startOffset), End: now.Add(endOffset)}
+}
+
+func TestStreamIsPast(t *testing.T) {
+	tests := []struct {
+		name   string
+		stream Stream
+		want   bool
+	}{
+		{
+			name:   "a stream whose end time has passed is past",
+			stream: streamAt(-2*time.Hour, -time.Hour),
+			want:   true,
+		},
+		{
+			name:   "a stream ending just moments ago is past",
+			stream: streamAt(-2*time.Hour, -time.Second),
+			want:   true,
+		},
+		{
+			name:   "a stream still running is not past",
+			stream: streamAt(-time.Hour, time.Hour),
+			want:   false,
+		},
+		{
+			name:   "a stream yet to start is not past",
+			stream: streamAt(time.Hour, 2*time.Hour),
+			want:   false,
+		},
+		{
+			// Ended is set by the worker when a live stream stops early; it must win
+			// over the scheduled end time or the UI keeps showing a dead player.
+			name: "a stream flagged as ended is past even though its slot is still running",
+			stream: func() Stream {
+				s := streamAt(-time.Hour, time.Hour)
+				s.Ended = true
+				return s
+			}(),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.stream.IsPast(); got != tt.want {
+				t.Errorf("IsPast() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStreamIsComingUp(t *testing.T) {
+	tests := []struct {
+		name   string
+		stream Stream
+		want   bool
+	}{
+		{
+			name:   "a stream starting in ten minutes is coming up",
+			stream: streamAt(10*time.Minute, 2*time.Hour),
+			want:   true,
+		},
+		{
+			// The 30 minute window is what flips the page from a countdown to a
+			// waiting room, so both sides of it are pinned.
+			name:   "a stream starting just inside the thirty minute window is coming up",
+			stream: streamAt(29*time.Minute, 2*time.Hour),
+			want:   true,
+		},
+		{
+			name:   "a stream starting just outside the thirty minute window is not coming up",
+			stream: streamAt(31*time.Minute, 2*time.Hour),
+			want:   false,
+		},
+		{
+			name:   "a stream whose slot has already begun is still coming up until it ends",
+			stream: streamAt(-10*time.Minute, time.Hour),
+			want:   true,
+		},
+		{
+			name:   "a past stream is never coming up",
+			stream: streamAt(-2*time.Hour, -time.Hour),
+			want:   false,
+		},
+		{
+			name: "a live stream is not coming up",
+			stream: func() Stream {
+				s := streamAt(-10*time.Minute, time.Hour)
+				s.LiveNow = true
+				return s
+			}(),
+			want: false,
+		},
+		{
+			name: "a recording is not coming up",
+			stream: func() Stream {
+				s := streamAt(-10*time.Minute, time.Hour)
+				s.Recording = true
+				return s
+			}(),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.stream.IsComingUp(); got != tt.want {
+				t.Errorf("IsComingUp() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStreamTimeSlotReached(t *testing.T) {
+	tests := []struct {
+		name   string
+		stream Stream
+		want   bool
+	}{
+		{
+			name:   "a stream currently in its slot has reached it",
+			stream: streamAt(-10*time.Minute, time.Hour),
+			want:   true,
+		},
+		{
+			// The one minute of lead time is deliberate: the countdown is hidden
+			// slightly before the start so it never renders "0:00".
+			name:   "a stream starting in thirty seconds has reached its slot",
+			stream: streamAt(30*time.Second, time.Hour),
+			want:   true,
+		},
+		{
+			name:   "a stream starting in two minutes has not reached its slot",
+			stream: streamAt(2*time.Minute, time.Hour),
+			want:   false,
+		},
+		{
+			name:   "a stream that already ended has not reached its slot any more",
+			stream: streamAt(-2*time.Hour, -time.Hour),
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.stream.TimeSlotReached(); got != tt.want {
+				t.Errorf("TimeSlotReached() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// BUG (asserted as-is, not fixed): IsStartingInOneDay is documented as "starts
+// within 1 day" but returns Start.After(now+24h), i.e. the exact opposite. Both
+// predicates are currently unreferenced outside this file, so the cases below pin
+// the implemented behaviour rather than the documented one.
+func TestStreamIsStartingInOneDay(t *testing.T) {
+	tests := []struct {
+		name                    string
+		stream                  Stream
+		wantOneDay, wantTwoDays bool
+	}{
+		{
+			name:       "a stream later today is not after either threshold",
+			stream:     streamAt(2*time.Hour, 3*time.Hour),
+			wantOneDay: false, wantTwoDays: false,
+		},
+		{
+			name:       "a stream just under twenty-four hours out is not after the one day threshold",
+			stream:     streamAt(23*time.Hour, 24*time.Hour),
+			wantOneDay: false, wantTwoDays: false,
+		},
+		{
+			name:       "a stream just over twenty-four hours out is after the one day threshold only",
+			stream:     streamAt(25*time.Hour, 26*time.Hour),
+			wantOneDay: true, wantTwoDays: false,
+		},
+		{
+			name:       "a stream just under forty-eight hours out is still not after the two day threshold",
+			stream:     streamAt(47*time.Hour, 48*time.Hour),
+			wantOneDay: true, wantTwoDays: false,
+		},
+		{
+			name:       "a stream three days out is after both thresholds",
+			stream:     streamAt(72*time.Hour, 73*time.Hour),
+			wantOneDay: true, wantTwoDays: true,
+		},
+		{
+			name:       "a past stream is after neither threshold",
+			stream:     streamAt(-72*time.Hour, -71*time.Hour),
+			wantOneDay: false, wantTwoDays: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.stream.IsStartingInOneDay(); got != tt.wantOneDay {
+				t.Errorf("IsStartingInOneDay() = %v, want %v", got, tt.wantOneDay)
+			}
+			if got := tt.stream.IsStartingInMoreThanOneDay(); got != tt.wantTwoDays {
+				t.Errorf("IsStartingInMoreThanOneDay() = %v, want %v", got, tt.wantTwoDays)
+			}
+			// The 48h window is contained in the 24h one; a refactor that breaks the
+			// nesting would make the UI claim both "soon" and "far away".
+			if tt.stream.IsStartingInMoreThanOneDay() && !tt.stream.IsStartingInOneDay() {
+				t.Error("IsStartingInMoreThanOneDay() without IsStartingInOneDay()")
+			}
+		})
+	}
+}
+
+func TestStreamIsPlanned(t *testing.T) {
+	tests := []struct {
+		name   string
+		stream Stream
+		want   bool
+	}{
+		{
+			name:   "a stream scheduled for next week is planned",
+			stream: streamAt(7*24*time.Hour, 7*24*time.Hour+time.Hour),
+			want:   true,
+		},
+		{
+			name:   "a stream about to start is no longer planned but coming up",
+			stream: streamAt(10*time.Minute, time.Hour),
+			want:   false,
+		},
+		{
+			name:   "a past stream is not planned",
+			stream: streamAt(-2*time.Hour, -time.Hour),
+			want:   false,
+		},
+		{
+			name: "a recording is not planned",
+			stream: func() Stream {
+				s := streamAt(7*24*time.Hour, 7*24*time.Hour+time.Hour)
+				s.Recording = true
+				return s
+			}(),
+			want: false,
+		},
+		{
+			name: "a live stream is not planned",
+			stream: func() Stream {
+				s := streamAt(7*24*time.Hour, 7*24*time.Hour+time.Hour)
+				s.LiveNow = true
+				return s
+			}(),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.stream.IsPlanned(); got != tt.want {
+				t.Errorf("IsPlanned() = %v, want %v", got, tt.want)
+			}
+			// Planned and coming up drive mutually exclusive UI states.
+			if tt.stream.IsPlanned() && tt.stream.IsComingUp() {
+				t.Error("stream is both planned and coming up")
+			}
+			if tt.stream.IsPlanned() && tt.stream.IsPast() {
+				t.Error("stream is both planned and past")
+			}
+		})
+	}
+}
+
+func TestStreamIsConverting(t *testing.T) {
+	var empty Stream
+	if empty.IsConverting() {
+		t.Error("a stream with no transcoding progress reports as converting")
+	}
+
+	converting := Stream{TranscodingProgresses: []TranscodingProgress{{Progress: 0}}}
+	// Progress zero still means a job exists; keying off the value instead of the
+	// slice length would hide a just-queued transcode.
+	if !converting.IsConverting() {
+		t.Error("a stream with a queued transcode does not report as converting")
+	}
+}
+
+func TestStreamIsDownloadable(t *testing.T) {
+	tests := []struct {
+		name   string
+		stream Stream
+		want   bool
+	}{
+		{
+			name:   "a recording with a combined playlist is downloadable",
+			stream: Stream{Recording: true, PlaylistUrl: "https://example.org/comb.m3u8"},
+			want:   true,
+		},
+		{
+			name:   "a recording with only a presentation playlist is downloadable",
+			stream: Stream{Recording: true, PlaylistUrlPRES: "https://example.org/pres.m3u8"},
+			want:   true,
+		},
+		{
+			name:   "a recording with only a camera playlist is downloadable",
+			stream: Stream{Recording: true, PlaylistUrlCAM: "https://example.org/cam.m3u8"},
+			want:   true,
+		},
+		{
+			name:   "a recording without any playlist is not downloadable",
+			stream: Stream{Recording: true},
+			want:   false,
+		},
+		{
+			// A live stream carries playlist URLs too; offering them as downloads
+			// would hand out a partial file.
+			name:   "a live stream with playlists is not downloadable",
+			stream: Stream{LiveNow: true, PlaylistUrl: "https://example.org/comb.m3u8"},
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.stream.IsDownloadable(); got != tt.want {
+				t.Errorf("IsDownloadable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStreamIsSelfStream(t *testing.T) {
+	// A zero LectureHallID is how "no lecture hall" is stored, so the zero value of
+	// a freshly created stream must read as self-streamed.
+	if !(&Stream{}).IsSelfStream() {
+		t.Error("a stream without a lecture hall is not treated as a self stream")
+	}
+	if (&Stream{LectureHallID: 1}).IsSelfStream() {
+		t.Error("a lecture hall stream is treated as a self stream")
+	}
+}
+
+func TestStreamGetStartInSeconds(t *testing.T) {
+	future := streamAt(time.Hour, 2*time.Hour)
+	if got := future.GetStartInSeconds(); got < 3590 || got > 3600 {
+		t.Errorf("GetStartInSeconds() = %d, want roughly 3600", got)
+	}
+
+	past := streamAt(-time.Hour, time.Hour)
+	if got := past.GetStartInSeconds(); got > -3590 || got < -3600 {
+		t.Errorf("GetStartInSeconds() = %d, want roughly -3600", got)
+	}
+
+	// Live and VoD both render a player, never a countdown, so the offset is
+	// suppressed regardless of the scheduled start.
+	live := streamAt(time.Hour, 2*time.Hour)
+	live.LiveNow = true
+	if got := live.GetStartInSeconds(); got != 0 {
+		t.Errorf("GetStartInSeconds() on a live stream = %d, want 0", got)
+	}
+
+	vod := streamAt(time.Hour, 2*time.Hour)
+	vod.Recording = true
+	if got := vod.GetStartInSeconds(); got != 0 {
+		t.Errorf("GetStartInSeconds() on a recording = %d, want 0", got)
+	}
+}
+
+func TestStreamGetVodFiles(t *testing.T) {
+	tests := []struct {
+		name   string
+		stream Stream
+		want   []DownloadableVod
+	}{
+		{
+			// The order is the order of the download dropdown entries.
+			name: "a stream with all three sources offers combined, camera and presentation",
+			stream: Stream{
+				PlaylistUrl:     "https://example.org/comb.m3u8?jwt=a",
+				PlaylistUrlCAM:  "https://example.org/cam.m3u8?jwt=b",
+				PlaylistUrlPRES: "https://example.org/pres.m3u8?jwt=c",
+			},
+			want: []DownloadableVod{
+				{FriendlyName: "Combined", DownloadURL: "https://example.org/comb.m3u8?jwt=a&download=1"},
+				{FriendlyName: "Camera", DownloadURL: "https://example.org/cam.m3u8?jwt=b&download=1"},
+				{FriendlyName: "Presentation", DownloadURL: "https://example.org/pres.m3u8?jwt=c&download=1"},
+			},
+		},
+		{
+			name:   "a stream with only a presentation source offers just that one",
+			stream: Stream{PlaylistUrlPRES: "https://example.org/pres.m3u8?jwt=c"},
+			want: []DownloadableVod{
+				{FriendlyName: "Presentation", DownloadURL: "https://example.org/pres.m3u8?jwt=c&download=1"},
+			},
+		},
+		{
+			// Must be an empty slice rather than nil: templates range over it and the
+			// value is marshalled into JSON where null would break the dropdown.
+			name:   "a stream with no sources offers nothing",
+			stream: Stream{},
+			want:   []DownloadableVod{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.stream.GetVodFiles()
+			if got == nil {
+				t.Fatal("GetVodFiles() returned nil")
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("GetVodFiles() = %+v, want %+v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("GetVodFiles()[%d] = %+v, want %+v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestStreamHLSUrl(t *testing.T) {
+	tests := []struct {
+		name   string
+		stream Stream
+		want   string
+	}{
+		{
+			name:   "a plain playlist url is passed through",
+			stream: Stream{PlaylistUrl: "https://example.org/stream/playlist.m3u8"},
+			want:   "https://example.org/stream/playlist.m3u8",
+		},
+		{
+			// The literal "quality" is stripped so the edge serves the master
+			// playlist instead of a fixed rendition.
+			name:   "the quality marker is removed from the url",
+			stream: Stream{PlaylistUrl: "https://example.org/stream/quality/playlist.m3u8"},
+			want:   "https://example.org/stream//playlist.m3u8",
+		},
+		{
+			name:   "a trimmed stream gets wowza start and duration parameters",
+			stream: Stream{PlaylistUrl: "https://example.org/p.m3u8", StartOffset: 60, EndOffset: 300},
+			want:   "https://example.org/p.m3u8?wowzaplaystart=60&wowzaplayduration=300",
+		},
+		{
+			// Only StartOffset gates the rewrite, so a missing EndOffset silently
+			// yields duration 0. Pinned as current behaviour.
+			name:   "a start offset without an end offset still produces a zero duration",
+			stream: Stream{PlaylistUrl: "https://example.org/p.m3u8", StartOffset: 60},
+			want:   "https://example.org/p.m3u8?wowzaplaystart=60&wowzaplayduration=0",
+		},
+		{
+			name:   "a stream without a playlist yields an empty url",
+			stream: Stream{},
+			want:   "",
+		},
+		{
+			// BUG (asserted as-is, not fixed): with no playlist but an offset set the
+			// result is a bare query string rather than an empty url.
+			name:   "a stream without a playlist but with an offset yields a bare query string",
+			stream: Stream{StartOffset: 60, EndOffset: 300},
+			want:   "?wowzaplaystart=60&wowzaplayduration=300",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.stream.HLSUrl(); got != tt.want {
+				t.Errorf("HLSUrl() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStreamAttachments(t *testing.T) {
+	s := Stream{Files: []File{
+		{Model: gorm.Model{ID: 1}, Type: FILETYPE_ATTACHMENT, Path: "/a/slides.pdf"},
+		{Model: gorm.Model{ID: 2}, Type: FILETYPE_THUMB_COMB, Path: "/a/thumb.jpg"},
+		{Model: gorm.Model{ID: 3}, Type: FILETYPE_ATTACHMENT, Path: "/a/notes.pdf"},
+	}}
+
+	got := s.Attachments()
+	if len(got) != 2 || got[0].ID != 1 || got[1].ID != 3 {
+		t.Fatalf("Attachments() = %+v, want the two attachment files", got)
+	}
+
+	// Empty, not nil: the attachment list is ranged over in templates.
+	if empty := (&Stream{}).Attachments(); empty == nil || len(empty) != 0 {
+		t.Errorf("Attachments() on a stream without files = %+v, want an empty slice", empty)
+	}
+}
+
+func TestStreamGetThumbIdForSource(t *testing.T) {
+	s := Stream{Files: []File{
+		{Model: gorm.Model{ID: 10}, Type: FILETYPE_THUMB_COMB},
+		{Model: gorm.Model{ID: 11}, Type: FILETYPE_THUMB_CAM},
+		{Model: gorm.Model{ID: 12}, Type: FILETYPE_THUMB_PRES},
+	}}
+
+	tests := []struct {
+		name   string
+		source string
+		want   uint
+	}{
+		{name: "the camera source resolves to the camera sprite", source: "CAM", want: 11},
+		{name: "the presentation source resolves to the presentation sprite", source: "PRES", want: 12},
+		{name: "the combined source resolves to the combined sprite", source: "COMB", want: 10},
+		{
+			// Anything unrecognised falls back to combined rather than erroring, which
+			// is what keeps the seek preview working for legacy player links.
+			name:   "an unknown source falls back to the combined sprite",
+			source: "nonsense",
+			want:   10,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := s.GetThumbIdForSource(tt.source); got != tt.want {
+				t.Errorf("GetThumbIdForSource(%q) = %d, want %d", tt.source, got, tt.want)
+			}
+		})
+	}
+
+	t.Run("a stream without thumbnails reports the invalid file id", func(t *testing.T) {
+		if got := (&Stream{}).GetThumbIdForSource("COMB"); got != FILETYPE_INVALID {
+			t.Errorf("GetThumbIdForSource() = %d, want FILETYPE_INVALID", got)
+		}
+	})
+}
+
+func TestStreamGetLGThumbnail(t *testing.T) {
+	file := func(t FileType, path string) File { return File{Type: t, Path: path} }
+
+	tests := []struct {
+		name   string
+		files  []File
+		want   string
+		wantOk bool
+	}{
+		{
+			// CAM_PRES is the composed preview and outranks every single-source
+			// thumbnail; the precedence chain is the whole point of this function.
+			name: "the combined camera and presentation thumbnail wins over all others",
+			files: []File{
+				file(FILETYPE_THUMB_LG_PRES, "/pres.jpg"),
+				file(FILETYPE_THUMB_LG_CAM, "/cam.jpg"),
+				file(FILETYPE_THUMB_LG_COMB, "/comb.jpg"),
+				file(FILETYPE_THUMB_LG_CAM_PRES, "/campres.jpg"),
+			},
+			want: "/campres.jpg", wantOk: true,
+		},
+		{
+			name: "the combined thumbnail wins over camera and presentation",
+			files: []File{
+				file(FILETYPE_THUMB_LG_PRES, "/pres.jpg"),
+				file(FILETYPE_THUMB_LG_CAM, "/cam.jpg"),
+				file(FILETYPE_THUMB_LG_COMB, "/comb.jpg"),
+			},
+			want: "/comb.jpg", wantOk: true,
+		},
+		{
+			name: "the camera thumbnail wins over presentation",
+			files: []File{
+				file(FILETYPE_THUMB_LG_PRES, "/pres.jpg"),
+				file(FILETYPE_THUMB_LG_CAM, "/cam.jpg"),
+			},
+			want: "/cam.jpg", wantOk: true,
+		},
+		{
+			name:  "the presentation thumbnail is used as the last resort",
+			files: []File{file(FILETYPE_THUMB_LG_PRES, "/pres.jpg")},
+			want:  "/pres.jpg", wantOk: true,
+		},
+		{
+			// Callers must not render an empty src; the error is the signal to fall
+			// back to a placeholder image.
+			name:  "a stream with only small thumbnails has no large thumbnail",
+			files: []File{file(FILETYPE_THUMB_COMB, "/sprite.jpg")},
+			want:  "", wantOk: false,
+		},
+		{
+			name:  "a stream without any files has no large thumbnail",
+			files: nil,
+			want:  "", wantOk: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Stream{Files: tt.files}
+			got, err := s.GetLGThumbnail()
+			if (err == nil) != tt.wantOk {
+				t.Fatalf("GetLGThumbnail() error = %v, want error: %v", err, !tt.wantOk)
+			}
+			if got != tt.want {
+				t.Errorf("GetLGThumbnail() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStreamGetLGThumbnailForVideoType(t *testing.T) {
+	s := Stream{Files: []File{
+		{Type: FILETYPE_THUMB_LG_COMB, Path: "/comb.jpg"},
+		{Type: FILETYPE_THUMB_LG_CAM, Path: "/cam.jpg"},
+		{Type: FILETYPE_THUMB_LG_PRES, Path: "/pres.jpg"},
+	}}
+
+	tests := []struct {
+		name      string
+		videoType VideoType
+		want      string
+		wantOk    bool
+	}{
+		{name: "the combined video type resolves to the combined thumbnail", videoType: VideoTypeCombined, want: "/comb.jpg", wantOk: true},
+		{name: "the camera video type resolves to the camera thumbnail", videoType: VideoTypeCamera, want: "/cam.jpg", wantOk: true},
+		{name: "the presentation video type resolves to the presentation thumbnail", videoType: VideoTypePresentation, want: "/pres.jpg", wantOk: true},
+		{
+			// An unmapped video type resolves to FILETYPE_INVALID and then matches
+			// nothing here; see the dedicated case below for why that is fragile.
+			name:      "an unknown video type has no thumbnail",
+			videoType: VideoType("BOGUS"),
+			want:      "", wantOk: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := s.GetLGThumbnailForVideoType(tt.videoType)
+			if (err == nil) != tt.wantOk {
+				t.Fatalf("GetLGThumbnailForVideoType(%q) error = %v, want error: %v", tt.videoType, err, !tt.wantOk)
+			}
+			if got != tt.want {
+				t.Errorf("GetLGThumbnailForVideoType(%q) = %q, want %q", tt.videoType, got, tt.want)
+			}
+		})
+	}
+
+	t.Run("a stream without files has no thumbnail for any video type", func(t *testing.T) {
+		if _, err := (&Stream{}).GetLGThumbnailForVideoType(VideoTypeCombined); err == nil {
+			t.Error("GetLGThumbnailForVideoType() returned no error for a stream without files")
+		}
+	})
+
+	// BUG (asserted as-is, not fixed): an unmapped video type looks up the zero
+	// FileType, so a file stored with FILETYPE_INVALID is handed back as if it were
+	// the requested thumbnail.
+	t.Run("an unknown video type matches a file stored with the invalid type", func(t *testing.T) {
+		bogus := Stream{Files: []File{{Type: FILETYPE_INVALID, Path: "/not-a-thumbnail"}}}
+		got, err := bogus.GetLGThumbnailForVideoType(VideoType("BOGUS"))
+		if err != nil || got != "/not-a-thumbnail" {
+			t.Errorf("GetLGThumbnailForVideoType() = (%q, %v), want the invalid-typed file (current behaviour)", got, err)
+		}
+	})
+}
+
+func TestStreamGetName(t *testing.T) {
+	named := Stream{Name: "Lecture 3: Monads"}
+	if got := named.GetName(); got != "Lecture 3: Monads" {
+		t.Errorf("GetName() = %q, want the stream name", got)
+	}
+
+	// Unnamed streams are common for auto-created TUMOnline events; the fallback
+	// must be derived from the start date, not left blank.
+	unnamed := Stream{Start: time.Date(2023, time.March, 7, 10, 0, 0, 0, time.UTC)}
+	if got := unnamed.GetName(); got != "Lecture: Mar 7, 2023" {
+		t.Errorf("GetName() = %q, want the date derived fallback", got)
+	}
+}
+
+func TestStreamColor(t *testing.T) {
+	past := streamAt(-2*time.Hour, -time.Hour)
+	upcoming := streamAt(7*24*time.Hour, 7*24*time.Hour+time.Hour)
+
+	tests := []struct {
+		name   string
+		stream Stream
+		want   string
+	}{
+		{
+			name: "a public recording is green",
+			stream: func() Stream {
+				s := past
+				s.Recording = true
+				return s
+			}(),
+			want: "success",
+		},
+		{
+			// Private recordings must be visually distinct; the recording branch is
+			// checked first so this is the only place the private flag shows up.
+			name: "a private recording is gray",
+			stream: func() Stream {
+				s := past
+				s.Recording, s.Private = true, true
+				return s
+			}(),
+			want: "gray-500",
+		},
+		{
+			name: "a live stream is red",
+			stream: func() Stream {
+				s := streamAt(-10*time.Minute, time.Hour)
+				s.LiveNow = true
+				return s
+			}(),
+			want: "danger",
+		},
+		{
+			// A slot that elapsed without producing a recording is the failure case
+			// operators need to spot.
+			name:   "a past stream without a recording is a warning",
+			stream: past,
+			want:   "warn",
+		},
+		{
+			name:   "an upcoming stream is neutral",
+			stream: upcoming,
+			want:   "info",
+		},
+		{
+			name: "a private upcoming stream is still neutral",
+			stream: func() Stream {
+				s := upcoming
+				s.Private = true
+				return s
+			}(),
+			want: "info",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.stream.Color(); got != tt.want {
+				t.Errorf("Color() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStreamGetSilencesJson(t *testing.T) {
+	tests := []struct {
+		name   string
+		stream Stream
+		want   string
+	}{
+		{
+			name: "silences are serialised as start and end pairs",
+			stream: Stream{Silences: []Silence{
+				{Start: 0, End: 30},
+				{Start: 600, End: 615},
+			}},
+			want: `[{"start":0,"end":30},{"start":600,"end":615}]`,
+		},
+		{
+			// The result is embedded straight into the player page, so the empty case
+			// must be an empty JSON array and never "" or "null".
+			name:   "a stream without silences serialises to an empty array",
+			stream: Stream{},
+			want:   "[]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.stream.GetSilencesJson()
+			if got != tt.want {
+				t.Errorf("GetSilencesJson() = %q, want %q", got, tt.want)
+			}
+			var parsed []map[string]uint
+			if err := json.Unmarshal([]byte(got), &parsed); err != nil {
+				t.Errorf("GetSilencesJson() produced invalid JSON: %v", err)
+			}
+		})
+	}
+}
+
+func TestStreamGetDescriptionHTML(t *testing.T) {
+	t.Run("markdown is rendered to html", func(t *testing.T) {
+		s := Stream{Description: "# Title\n\nSome **bold** text."}
+		got := s.GetDescriptionHTML()
+		if !strings.Contains(got, "<h1>") || !strings.Contains(got, "<strong>bold</strong>") {
+			t.Errorf("GetDescriptionHTML() = %q, want rendered markdown", got)
+		}
+	})
+
+	t.Run("an empty description renders to nothing", func(t *testing.T) {
+		if got := (&Stream{}).GetDescriptionHTML(); got != "" {
+			t.Errorf("GetDescriptionHTML() = %q, want an empty string", got)
+		}
+	})
+
+	// Lecturer-supplied descriptions are rendered unescaped into the course page.
+	// This is the XSS boundary: anything the sanitiser lets through executes in the
+	// viewer's session.
+	t.Run("script tags and event handlers are stripped", func(t *testing.T) {
+		s := Stream{Description: `Hello <script>alert('xss')</script> <img src=x onerror="alert(1)"> <a href="javascript:alert(1)">click</a>`}
+		got := s.GetDescriptionHTML()
+		for _, forbidden := range []string{"<script", "onerror", "javascript:", "alert(1)"} {
+			if strings.Contains(strings.ToLower(got), strings.ToLower(forbidden)) {
+				t.Errorf("GetDescriptionHTML() = %q, still contains %q", got, forbidden)
+			}
+		}
+		if !strings.Contains(got, "Hello") {
+			t.Errorf("GetDescriptionHTML() = %q, dropped the benign text", got)
+		}
+	})
+
+	t.Run("fully qualified links open in a new tab", func(t *testing.T) {
+		s := Stream{Description: "See [the docs](https://example.org/docs)."}
+		got := s.GetDescriptionHTML()
+		if !strings.Contains(got, `target="_blank"`) {
+			t.Errorf("GetDescriptionHTML() = %q, want target=_blank on an external link", got)
+		}
+	})
+}
+
+func TestStreamFirstSilenceAsProgress(t *testing.T) {
+	hourLong := func(silences ...Silence) Stream {
+		start := time.Date(2023, time.March, 7, 10, 0, 0, 0, time.UTC)
+		return Stream{Start: start, End: start.Add(time.Hour), Silences: silences}
+	}
+
+	tests := []struct {
+		name   string
+		stream Stream
+		want   float64
+	}{
+		{
+			name:   "a silence covering the first six minutes is a tenth of the way in",
+			stream: hourLong(Silence{Start: 0, End: 360}),
+			want:   0.1,
+		},
+		{
+			name:   "a stream without silences reports no progress",
+			stream: hourLong(),
+			want:   0,
+		},
+		{
+			// The value is only meaningful as a skip-intro marker, so a silence that
+			// does not start at zero must be ignored rather than scaled.
+			name:   "a silence that does not begin at the start is ignored",
+			stream: hourLong(Silence{Start: 120, End: 360}),
+			want:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.stream.FirstSilenceAsProgress()
+			if math.Abs(got-tt.want) > 1e-9 {
+				t.Errorf("FirstSilenceAsProgress() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+	// BUG (asserted as-is, not fixed): a zero-length slot divides by zero and yields
+	// +Inf, which serialises to invalid JSON and renders as a broken progress bar.
+	t.Run("a zero length stream divides by zero", func(t *testing.T) {
+		at := time.Date(2023, time.March, 7, 10, 0, 0, 0, time.UTC)
+		s := Stream{Start: at, End: at, Silences: []Silence{{Start: 0, End: 360}}}
+		if got := s.FirstSilenceAsProgress(); !math.IsInf(got, 1) {
+			t.Errorf("FirstSilenceAsProgress() = %v, want +Inf (current behaviour)", got)
+		}
+	})
+
+	t.Run("a zero length stream with a zero length silence is not a number", func(t *testing.T) {
+		at := time.Date(2023, time.March, 7, 10, 0, 0, 0, time.UTC)
+		s := Stream{Start: at, End: at, Silences: []Silence{{Start: 0, End: 0}}}
+		if got := s.FirstSilenceAsProgress(); !math.IsNaN(got) {
+			t.Errorf("FirstSilenceAsProgress() = %v, want NaN (current behaviour)", got)
+		}
+	})
+}
+
+func TestParsableTimeFormat(t *testing.T) {
+	at := time.Date(2023, time.March, 7, 14, 5, 9, 0, time.UTC)
+	if got := ParsableTimeFormat(at); got != "2023-03-07 14:05:09" {
+		t.Errorf("ParsableTimeFormat() = %q, want the JS parsable layout", got)
+	}
+
+	// A zero time must render as the empty string, not "0001-01-01 ...", or the
+	// frontend shows a year-one date for streams that never went live.
+	if got := ParsableTimeFormat(time.Time{}); got != "" {
+		t.Errorf("ParsableTimeFormat(zero) = %q, want an empty string", got)
+	}
+
+	s := Stream{Start: at, LiveNowTimestamp: at.Add(time.Minute)}
+	if got := s.ParsableStartTime(); got != "2023-03-07 14:05:09" {
+		t.Errorf("ParsableStartTime() = %q", got)
+	}
+	if got := s.ParsableLiveNowTimestamp(); got != "2023-03-07 14:06:09" {
+		t.Errorf("ParsableLiveNowTimestamp() = %q", got)
+	}
+	if got := (&Stream{Start: at}).ParsableLiveNowTimestamp(); got != "" {
+		t.Errorf("ParsableLiveNowTimestamp() with no timestamp = %q, want an empty string", got)
+	}
+}
+
+func TestStreamFriendlyDateAndTime(t *testing.T) {
+	// Fixed dates only: these are pure formatters, so nothing here depends on when
+	// the suite runs.
+	start := time.Date(2023, time.March, 7, 10, 15, 0, 0, time.UTC)
+	s := Stream{Start: start, End: start.Add(90 * time.Minute)}
+
+	if got := s.FriendlyDate(); got != "Tue 07.03.2023" {
+		t.Errorf("FriendlyDate() = %q", got)
+	}
+	if got := s.FriendlyTime(); got != "07.03.2023 10:15 - 11:45" {
+		t.Errorf("FriendlyTime() = %q", got)
+	}
+}
+
+func TestStreamFriendlyNextDate(t *testing.T) {
+	// Relative to now by necessity: the function compares against the current day.
+	// Offsets are kept well away from midnight boundaries in the far-future case.
+	t.Run("a stream today is labelled today", func(t *testing.T) {
+		start := time.Now()
+		s := Stream{Start: start}
+		want := start.Format("Today, 15:04")
+		if got := s.FriendlyNextDate(); got != want {
+			t.Errorf("FriendlyNextDate() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("a stream tomorrow is labelled tomorrow", func(t *testing.T) {
+		start := time.Now().Add(24 * time.Hour)
+		s := Stream{Start: start}
+		want := start.Format("Tomorrow, 15:04")
+		if got := s.FriendlyNextDate(); got != want {
+			t.Errorf("FriendlyNextDate() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("a stream further out is labelled with its date", func(t *testing.T) {
+		start := time.Now().Add(5 * 24 * time.Hour)
+		s := Stream{Start: start}
+		want := start.Format("Mon, January 02. 15:04")
+		if got := s.FriendlyNextDate(); got != want {
+			t.Errorf("FriendlyNextDate() = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestStreamToDTO(t *testing.T) {
+	start := time.Now().Add(7 * 24 * time.Hour)
+
+	t.Run("a planned stream carries no downloads", func(t *testing.T) {
+		s := Stream{
+			Model:       gorm.Model{ID: 5},
+			Name:        "Week 1",
+			Description: "Intro",
+			Start:       start,
+			End:         start.Add(90 * time.Minute),
+			RoomCode:    "00.13.009A",
+			PlaylistUrl: "https://example.org/p.m3u8",
+		}
+		dto := s.ToDTO()
+		if dto.ID != 5 || dto.Name != "Week 1" || dto.Description != "Intro" {
+			t.Errorf("ToDTO() = %+v, want the stream identity fields", dto)
+		}
+		// Downloads are gated on IsDownloadable; a scheduled stream exposing its
+		// playlist as a download would leak an unfinished recording.
+		if dto.Downloads != nil {
+			t.Errorf("ToDTO().Downloads = %+v, want nil for a non-recording", dto.Downloads)
+		}
+		if !dto.IsPlanned || dto.IsComingUp || dto.IsRecording {
+			t.Errorf("ToDTO() state = planned:%v comingUp:%v recording:%v", dto.IsPlanned, dto.IsComingUp, dto.IsRecording)
+		}
+		if dto.Duration != 5400 {
+			t.Errorf("ToDTO().Duration = %d, want the slot length in seconds", dto.Duration)
+		}
+		if dto.LectureHall != "00.13.009A" {
+			t.Errorf("ToDTO().LectureHall = %q, want the room code", dto.LectureHall)
+		}
+		if !dto.IsPubliclyVisible {
+			t.Error("ToDTO().IsPubliclyVisible = false for a public stream")
+		}
+	})
+
+	t.Run("a recording carries its downloads and measured duration", func(t *testing.T) {
+		s := Stream{
+			Start:          start.Add(-14 * 24 * time.Hour),
+			End:            start.Add(-14*24*time.Hour + 90*time.Minute),
+			Recording:      true,
+			Private:        true,
+			PlaylistUrl:    "https://example.org/comb.m3u8",
+			PlaylistUrlCAM: "https://example.org/cam.m3u8",
+			// The measured duration overrides the scheduled slot: recordings routinely
+			// run shorter than they were booked for.
+			Duration: sql.NullInt32{Int32: 4200, Valid: true},
+		}
+		dto := s.ToDTO()
+		if len(dto.Downloads) != 2 {
+			t.Errorf("ToDTO().Downloads = %+v, want both sources", dto.Downloads)
+		}
+		if dto.Duration != 4200 {
+			t.Errorf("ToDTO().Duration = %d, want the measured duration", dto.Duration)
+		}
+		if dto.IsPubliclyVisible {
+			t.Error("ToDTO().IsPubliclyVisible = true for a private stream")
+		}
+	})
+}
+
+func TestStreamGetJson(t *testing.T) {
+	start := time.Now().Add(7 * 24 * time.Hour)
+	s := Stream{
+		Model:         gorm.Model{ID: 3},
+		Name:          "Week 2",
+		CourseID:      9,
+		LectureHallID: 2,
+		Start:         start,
+		End:           start.Add(time.Hour),
+		PlaylistUrl:   "https://example.org/comb.m3u8",
+		Files:         []File{{Model: gorm.Model{ID: 1}, Type: FILETYPE_ATTACHMENT, Path: "/x/CAM.mp4"}},
+		VideoSections: []VideoSection{{Model: gorm.Model{ID: 4}, Description: "Intro", StartHours: 0, StartMinutes: 1, StartSeconds: 2, FileID: 1}},
+	}
+	halls := []LectureHall{{Model: gorm.Model{ID: 1}, Name: "HS1"}, {Model: gorm.Model{ID: 2}, Name: "HS2"}}
+
+	got := s.GetJson(halls, &Course{Slug: "eidi"})
+
+	if got["lectureId"] != uint(3) || got["courseId"] != uint(9) || got["courseSlug"] != "eidi" {
+		t.Errorf("GetJson() identity fields = %+v", got)
+	}
+	if got["lectureHallName"] != "HS2" {
+		t.Errorf("GetJson()[lectureHallName] = %v, want the matching hall", got["lectureHallName"])
+	}
+	if got["hasStats"] != false {
+		t.Errorf("GetJson()[hasStats] = %v, want false without stats", got["hasStats"])
+	}
+
+	// A self stream has no hall to resolve; the placeholder is what the admin UI
+	// renders in the lecture hall column.
+	self := Stream{Start: start, End: start.Add(time.Hour)}
+	if name := self.GetJson(halls, &Course{})["lectureHallName"]; name != "Selfstreaming" {
+		t.Errorf("GetJson()[lectureHallName] = %v, want Selfstreaming", name)
+	}
+
+	// The payload is marshalled straight into the admin page.
+	if _, err := json.Marshal(got); err != nil {
+		t.Errorf("GetJson() produced unmarshalable output: %v", err)
+	}
+}

--- a/model/user_test.go
+++ b/model/user_test.go
@@ -1,0 +1,841 @@
+package model
+
+import (
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/argon2"
+	"gorm.io/gorm"
+)
+
+// Course visibilities used across the access control tests. They are the four values
+// the Visibility column may hold; a typo in one of them would silently make a course
+// behave as "enrolled", which is why they are spelled once here.
+var (
+	publicCourse   = Course{Model: gorm.Model{ID: 1}, Visibility: "public", UserID: 100}
+	loggedInCourse = Course{Model: gorm.Model{ID: 2}, Visibility: "loggedin", UserID: 100}
+	enrolledCourse = Course{Model: gorm.Model{ID: 3}, Visibility: "enrolled", UserID: 100}
+	hiddenCourse   = Course{Model: gorm.Model{ID: 4}, Visibility: "hidden", UserID: 100}
+)
+
+func student(id uint, enrolledIn ...Course) *User {
+	return &User{Model: gorm.Model{ID: id}, Role: StudentType, Courses: enrolledIn}
+}
+
+// IsEligibleToWatchCourse decides whether a stream may be played at all, so every
+// visibility is pinned against every kind of caller including the anonymous one.
+func TestIsEligibleToWatchCourse(t *testing.T) {
+	admin := &User{Model: gorm.Model{ID: 1}, Role: AdminType}
+	owner := &User{Model: gorm.Model{ID: 100}, Role: LecturerType}
+	granted := &User{Model: gorm.Model{ID: 2}, Role: LecturerType, AdministeredCourses: []Course{enrolledCourse}}
+	otherLecturer := &User{Model: gorm.Model{ID: 3}, Role: LecturerType, AdministeredCourses: []Course{publicCourse}}
+
+	tests := []struct {
+		name   string
+		user   *User
+		course Course
+		want   bool
+	}{
+		{"an anonymous caller may watch a public course", nil, publicCourse, true},
+		// Hidden means unlisted, not private: an unauthenticated caller holding the
+		// link is deliberately still allowed in.
+		{"an anonymous caller may watch a hidden course", nil, hiddenCourse, true},
+		{"an anonymous caller may not watch a loggedin course", nil, loggedInCourse, false},
+		{"an anonymous caller may not watch an enrolled course", nil, enrolledCourse, false},
+
+		{"any signed in user may watch a loggedin course", student(10), loggedInCourse, true},
+		{"a student not enrolled may not watch an enrolled course", student(10), enrolledCourse, false},
+		{"a student enrolled may watch an enrolled course", student(10, enrolledCourse), enrolledCourse, true},
+		// The enrolment list is matched by course ID, so an enrolment in some other
+		// course must not leak access.
+		{"a student enrolled elsewhere may not watch an enrolled course", student(10, publicCourse), enrolledCourse, false},
+
+		{"an admin may watch an enrolled course they are not in", admin, enrolledCourse, true},
+		{"the owner may watch their own enrolled course", owner, enrolledCourse, true},
+		{"a lecturer granted the course may watch it", granted, enrolledCourse, true},
+		{"a lecturer granted a different course may not", otherLecturer, enrolledCourse, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.user.IsEligibleToWatchCourse(tt.course); got != tt.want {
+				t.Errorf("IsEligibleToWatchCourse = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// IsAllowedToWatchPrivateCourse is the gate used for courses that are not public; it
+// must never widen to an anonymous caller, not even for a public or hidden course.
+func TestIsAllowedToWatchPrivateCourse(t *testing.T) {
+	tests := []struct {
+		name   string
+		user   *User
+		course Course
+		want   bool
+	}{
+		// Unlike IsEligibleToWatchCourse this returns false for nil before it ever
+		// looks at the visibility.
+		{"an anonymous caller is refused even for a public course", nil, publicCourse, false},
+		{"an anonymous caller is refused even for a hidden course", nil, hiddenCourse, false},
+		{"an enrolled student is allowed", student(10, enrolledCourse), enrolledCourse, true},
+		{"an unenrolled student is refused", student(10), enrolledCourse, false},
+		{"a signed in user is allowed a loggedin course", student(10), loggedInCourse, true},
+		{"an admin is allowed", &User{Model: gorm.Model{ID: 1}, Role: AdminType}, enrolledCourse, true},
+		{"the owner is allowed", &User{Model: gorm.Model{ID: 100}, Role: LecturerType}, enrolledCourse, true},
+		{
+			"a lecturer granted the course is allowed",
+			&User{Model: gorm.Model{ID: 2}, Role: LecturerType, AdministeredCourses: []Course{enrolledCourse}},
+			enrolledCourse, true,
+		},
+		{
+			"a lecturer granted a different course is refused",
+			&User{Model: gorm.Model{ID: 3}, Role: LecturerType, AdministeredCourses: []Course{publicCourse}},
+			enrolledCourse, false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.user.IsAllowedToWatchPrivateCourse(tt.course); got != tt.want {
+				t.Errorf("IsAllowedToWatchPrivateCourse = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Search results are the one place a hidden course must not surface: being able to
+// watch it with the link does not mean it may be listed.
+func TestIsEligibleToSearchForCourse(t *testing.T) {
+	tests := []struct {
+		name   string
+		user   *User
+		course Course
+		want   bool
+	}{
+		{"an anonymous caller finds a public course", nil, publicCourse, true},
+		{"an anonymous caller does not find a hidden course", nil, hiddenCourse, false},
+		{"a signed in user does not find a hidden course", student(10), hiddenCourse, false},
+		// Enrolment alone does not unhide it; only administration does.
+		{"a student enrolled in a hidden course still does not find it", student(10, hiddenCourse), hiddenCourse, false},
+		{"an admin finds a hidden course", &User{Model: gorm.Model{ID: 1}, Role: AdminType}, hiddenCourse, true},
+		{"the owner finds their own hidden course", &User{Model: gorm.Model{ID: 100}, Role: LecturerType}, hiddenCourse, true},
+		{"an enrolled student finds an enrolled course", student(10, enrolledCourse), enrolledCourse, true},
+		{"an unenrolled student does not find an enrolled course", student(10), enrolledCourse, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.user.IsEligibleToSearchForCourse(tt.course); got != tt.want {
+				t.Errorf("IsEligibleToSearchForCourse = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Every access check must tolerate the anonymous caller: these are reached from
+// handlers before authentication is established.
+func TestAccessChecksDoNotPanicOnNilUser(t *testing.T) {
+	var u *User
+	for _, c := range []Course{publicCourse, loggedInCourse, enrolledCourse, hiddenCourse} {
+		u.IsEligibleToWatchCourse(c)
+		u.IsAllowedToWatchPrivateCourse(c)
+		u.IsEligibleToSearchForCourse(c)
+		if u.IsAdminOfCourse(c) {
+			t.Errorf("nil user administers course %d", c.ID)
+		}
+	}
+}
+
+// A password round trip is the login path; the wrong-password and empty-hash cases are
+// what keep a broken comparison from admitting everyone.
+func TestSetPasswordAndCompare(t *testing.T) {
+	restoreArgonParams(t)
+
+	t.Run("a correct password matches", func(t *testing.T) {
+		u := &User{}
+		if err := u.SetPassword("hunter2hunter2"); err != nil {
+			t.Fatalf("SetPassword: %v", err)
+		}
+		match, err := u.ComparePasswordAndHash("hunter2hunter2")
+		if err != nil {
+			t.Fatalf("ComparePasswordAndHash: %v", err)
+		}
+		if !match {
+			t.Error("the password that was set does not match its own hash")
+		}
+	})
+
+	t.Run("a wrong password does not match", func(t *testing.T) {
+		u := &User{}
+		if err := u.SetPassword("hunter2hunter2"); err != nil {
+			t.Fatalf("SetPassword: %v", err)
+		}
+		match, err := u.ComparePasswordAndHash("hunter2hunter3")
+		if err != nil {
+			t.Fatalf("ComparePasswordAndHash: %v", err)
+		}
+		if match {
+			t.Error("a wrong password matched")
+		}
+	})
+
+	t.Run("a short password is rejected", func(t *testing.T) {
+		u := &User{Password: "untouched"}
+		if err := u.SetPassword("1234567"); err == nil {
+			t.Error("a 7 character password was accepted")
+		}
+		if u.Password != "untouched" {
+			t.Error("a rejected password still overwrote the stored hash")
+		}
+	})
+
+	// An account with no password (the usual case: everyone who signs in via SSO)
+	// must not be loggable into with the empty string.
+	t.Run("a user without a password never matches", func(t *testing.T) {
+		u := &User{}
+		for _, attempt := range []string{"", "anything"} {
+			match, err := u.ComparePasswordAndHash(attempt)
+			if err != nil || match {
+				t.Errorf("ComparePasswordAndHash(%q) = %v, %v; want false, nil", attempt, match, err)
+			}
+		}
+	})
+
+	// A hash column corrupted by a bad migration must surface as an error rather than
+	// as a successful login.
+	t.Run("a malformed stored hash reports an error", func(t *testing.T) {
+		u := &User{Password: "not-a-hash"}
+		match, err := u.ComparePasswordAndHash("whatever")
+		if err == nil {
+			t.Error("a malformed stored hash did not report an error")
+		}
+		if match {
+			t.Error("a malformed stored hash matched")
+		}
+	})
+}
+
+// If the salt were ever fixed, two users with the same password would share a hash and
+// the whole table would be crackable at once.
+func TestGenerateFromPasswordSaltsEachHash(t *testing.T) {
+	restoreArgonParams(t)
+
+	first, err := GenerateFromPassword("hunter2hunter2")
+	if err != nil {
+		t.Fatalf("GenerateFromPassword: %v", err)
+	}
+	second, err := GenerateFromPassword("hunter2hunter2")
+	if err != nil {
+		t.Fatalf("GenerateFromPassword: %v", err)
+	}
+	if first == second {
+		t.Error("two hashes of the same password are identical, so the salt is not random")
+	}
+
+	// The encoding is parsed back by decodeHash and by other argon2 tooling, so its
+	// shape is part of the contract.
+	if !strings.HasPrefix(first, "$argon2id$v=") {
+		t.Errorf("unexpected hash encoding: %q", first)
+	}
+	if n := len(strings.Split(first, "$")); n != 6 {
+		t.Errorf("hash has %d $-separated fields, want 6", n)
+	}
+}
+
+// decodeHash parses attacker-adjacent data (whatever sits in the password column), so
+// every malformed shape must come back as an error instead of a panic or a false match.
+func TestDecodeHashRejectsMalformedInput(t *testing.T) {
+	restoreArgonParams(t)
+
+	valid, err := GenerateFromPassword("hunter2hunter2")
+	if err != nil {
+		t.Fatalf("GenerateFromPassword: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		encoded string
+		wantErr error // nil means "any error"
+	}{
+		{"an empty string", "", ErrInvalidHash},
+		{"a string with no separators", "argon2id", ErrInvalidHash},
+		{"a truncated hash missing the derived key", strings.Join(strings.Split(valid, "$")[:5], "$"), ErrInvalidHash},
+		{"a hash with an extra field", valid + "$extra", ErrInvalidHash},
+		{"an unparsable version field", "$argon2id$version$m=65536,t=3,p=2$c2FsdHNhbHRzYWx0$aGFzaA", nil},
+		{"an older argon2 version", "$argon2id$v=18$m=65536,t=3,p=2$c2FsdHNhbHRzYWx0$aGFzaA", ErrIncompatibleVersion},
+		{"an unparsable parameter field", "$argon2id$v=19$m=lots,t=3,p=2$c2FsdHNhbHRzYWx0$aGFzaA", nil},
+		{"a salt that is not base64", "$argon2id$v=19$m=65536,t=3,p=2$not base64!$aGFzaA", nil},
+		{"a derived key that is not base64", "$argon2id$v=19$m=65536,t=3,p=2$c2FsdHNhbHRzYWx0$not base64!", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			salt, hash, err := decodeHash(tt.encoded)
+			if err == nil {
+				t.Fatalf("decodeHash(%q) accepted the input", tt.encoded)
+			}
+			if tt.wantErr != nil && !errors.Is(err, tt.wantErr) {
+				t.Errorf("decodeHash error = %v, want %v", err, tt.wantErr)
+			}
+			if salt != nil || hash != nil {
+				t.Error("decodeHash returned material alongside an error")
+			}
+		})
+	}
+
+	t.Run("a hash generated here round trips", func(t *testing.T) {
+		salt, hash, err := decodeHash(valid)
+		if err != nil {
+			t.Fatalf("decodeHash: %v", err)
+		}
+		if len(salt) == 0 || len(hash) == 0 {
+			t.Fatalf("decodeHash returned salt=%d bytes, hash=%d bytes", len(salt), len(hash))
+		}
+	})
+}
+
+// BUG (asserted as-is, not fixed): decodeHash writes the parameters it parsed into the
+// package level `p`, so verifying one user's hash changes the cost parameters used to
+// generate everyone else's from then on — and races when two logins decode at once.
+// This pins the current behaviour so a fix is a deliberate, visible change.
+func TestDecodeHashMutatesGlobalParameters(t *testing.T) {
+	restoreArgonParams(t)
+
+	// Same argon2 version, but half the memory of the configured parameters.
+	weak := "$argon2id$v=19$m=32768,t=1,p=1$c2FsdHNhbHRzYWx0$aGFzaGhhc2hoYXNo"
+	if _, _, err := decodeHash(weak); err != nil {
+		t.Fatalf("decodeHash: %v", err)
+	}
+	if p.memory != 32768 || p.iterations != 1 || p.parallelism != 1 {
+		t.Errorf("global params = %+v; the mutation this test documents seems to be gone", p)
+	}
+}
+
+// restoreArgonParams puts the package level argon2 parameters back after a test, since
+// decodeHash overwrites them (see TestDecodeHashMutatesGlobalParameters).
+func restoreArgonParams(t *testing.T) {
+	t.Helper()
+	saved := p
+	t.Cleanup(func() { p = saved })
+}
+
+// The settings table stores raw strings for some keys and JSON for others; a missing or
+// unparsable row must fall back to the documented default rather than blank the UI.
+func TestSettingsDefaultsAndFallbacks(t *testing.T) {
+	t.Run("a user without settings gets the defaults", func(t *testing.T) {
+		u := &User{Name: "Ada"}
+		if got := u.GetPreferredName(); got != "Ada" {
+			t.Errorf("GetPreferredName = %q, want the account name", got)
+		}
+		if got := u.GetPreferredGreeting(); got != "Moin" {
+			t.Errorf("GetPreferredGreeting = %q, want %q", got, "Moin")
+		}
+		if got := u.GetPreferredView(); got != "Combined" {
+			t.Errorf("GetPreferredView = %q, want %q", got, "Combined")
+		}
+		if got := u.GetSeekingTime(); got != 10 {
+			t.Errorf("GetSeekingTime = %d, want 10", got)
+		}
+		if !u.PreferredNameChangeAllowed() {
+			t.Error("a user who never set a preferred name may not change it")
+		}
+	})
+
+	t.Run("a set value is returned verbatim", func(t *testing.T) {
+		u := &User{Name: "Ada", Settings: []UserSetting{
+			{Type: PreferredName, Value: "Ada L."},
+			{Type: Greeting, Value: "Hi"},
+			{Type: LectureView, Value: "Presentation"},
+			{Type: SeekingTime, Value: "30"},
+		}}
+		if got := u.GetPreferredName(); got != "Ada L." {
+			t.Errorf("GetPreferredName = %q", got)
+		}
+		if got := u.GetPreferredGreeting(); got != "Hi" {
+			t.Errorf("GetPreferredGreeting = %q", got)
+		}
+		if got := u.GetPreferredView(); got != "Presentation" {
+			t.Errorf("GetPreferredView = %q", got)
+		}
+		if got := u.GetSeekingTime(); got != 30 {
+			t.Errorf("GetSeekingTime = %d, want 30", got)
+		}
+	})
+
+	// Duplicate rows for one key are possible (nothing enforces uniqueness); the first
+	// row in the slice wins, so it is first-write-wins, not last.
+	t.Run("the first of two rows for a key wins", func(t *testing.T) {
+		u := &User{Name: "Ada", Settings: []UserSetting{
+			{Type: Greeting, Value: "first"},
+			{Type: Greeting, Value: "second"},
+		}}
+		if got := u.GetPreferredGreeting(); got != "first" {
+			t.Errorf("GetPreferredGreeting = %q, want %q", got, "first")
+		}
+	})
+}
+
+// A seeking time outside the offered choices would produce a player control that does
+// not match its label, so anything unexpected collapses to the default.
+func TestGetSeekingTime(t *testing.T) {
+	tests := []struct {
+		name string
+		user *User
+		want int
+	}{
+		{"an anonymous caller gets the default", nil, 10},
+		{"5 seconds is accepted", &User{Settings: []UserSetting{{Type: SeekingTime, Value: "5"}}}, 5},
+		{"10 seconds is accepted", &User{Settings: []UserSetting{{Type: SeekingTime, Value: "10"}}}, 10},
+		{"30 seconds is accepted", &User{Settings: []UserSetting{{Type: SeekingTime, Value: "30"}}}, 30},
+		{"an unoffered value falls back", &User{Settings: []UserSetting{{Type: SeekingTime, Value: "17"}}}, 10},
+		{"a negative value falls back", &User{Settings: []UserSetting{{Type: SeekingTime, Value: "-5"}}}, 10},
+		{"a non numeric value falls back", &User{Settings: []UserSetting{{Type: SeekingTime, Value: "fast"}}}, 10},
+		{"an empty value falls back", &User{Settings: []UserSetting{{Type: SeekingTime, Value: ""}}}, 10},
+		// The column is JSON for other settings, so a JSON number is a plausible
+		// mistake; strconv.Atoi rejects it and the default applies.
+		{"a quoted number falls back", &User{Settings: []UserSetting{{Type: SeekingTime, Value: `"10"`}}}, 10},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.user.GetSeekingTime(); got != tt.want {
+				t.Errorf("GetSeekingTime = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// The playback speed rows are JSON written by the client; malformed content must not
+// take the player down with it.
+func TestGetPlaybackSpeeds(t *testing.T) {
+	t.Run("an anonymous caller gets the defaults", func(t *testing.T) {
+		var u *User
+		if got := u.GetPlaybackSpeeds(); len(got) != len(defaultPlaybackSpeeds) {
+			t.Errorf("GetPlaybackSpeeds returned %d entries, want %d", len(got), len(defaultPlaybackSpeeds))
+		}
+		if got := u.GetCustomSpeeds(); len(got) != 0 {
+			t.Errorf("GetCustomSpeeds = %v, want empty", got)
+		}
+	})
+
+	t.Run("a stored setting replaces the defaults", func(t *testing.T) {
+		u := &User{Settings: []UserSetting{{
+			Type:  CustomPlaybackSpeeds,
+			Value: `[{"speed":1,"enabled":true},{"speed":2,"enabled":false}]`,
+		}}}
+		speeds := u.GetPlaybackSpeeds()
+		if len(speeds) != 2 || speeds[0].Speed != 1 || speeds[1].Enabled {
+			t.Errorf("GetPlaybackSpeeds = %+v", speeds)
+		}
+		if enabled := speeds.GetEnabled(); len(enabled) != 1 || enabled[0] != 1 {
+			t.Errorf("GetEnabled = %v, want [1]", enabled)
+		}
+	})
+
+	t.Run("malformed json falls back to the defaults", func(t *testing.T) {
+		for _, value := range []string{"", "{", "null-ish", `{"speed":1}`} {
+			u := &User{Settings: []UserSetting{{Type: CustomPlaybackSpeeds, Value: value}}}
+			if got := u.GetPlaybackSpeeds(); len(got) != len(defaultPlaybackSpeeds) {
+				t.Errorf("value %q: GetPlaybackSpeeds returned %d entries, want the %d defaults", value, len(got), len(defaultPlaybackSpeeds))
+			}
+		}
+	})
+
+	t.Run("malformed custom speeds fall back to empty", func(t *testing.T) {
+		for _, value := range []string{"", "[1,", `{"a":1}`} {
+			u := &User{Settings: []UserSetting{{Type: UserDefinedSpeeds, Value: value}}}
+			if got := u.GetCustomSpeeds(); len(got) != 0 {
+				t.Errorf("value %q: GetCustomSpeeds = %v, want empty", value, got)
+			}
+		}
+	})
+}
+
+// The enabled list is what the player renders, so both halves (the toggled defaults and
+// the user's own additions) must appear, in ascending order.
+func TestGetEnabledPlaybackSpeeds(t *testing.T) {
+	t.Run("the defaults are the enabled ones in order", func(t *testing.T) {
+		u := &User{}
+		want := []float32{0.5, 0.75, 1, 1.25, 1.5, 1.75, 2}
+		assertSpeeds(t, u.GetEnabledPlaybackSpeeds(), want)
+	})
+
+	t.Run("custom speeds are merged and sorted", func(t *testing.T) {
+		u := &User{Settings: []UserSetting{
+			{Type: CustomPlaybackSpeeds, Value: `[{"speed":1,"enabled":true},{"speed":2,"enabled":false}]`},
+			{Type: UserDefinedSpeeds, Value: `[3, 0.1]`},
+		}}
+		assertSpeeds(t, u.GetEnabledPlaybackSpeeds(), []float32{0.1, 1, 3})
+	})
+}
+
+func assertSpeeds(t *testing.T, got, want []float32) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("speeds = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("speeds = %v, want %v", got, want)
+		}
+	}
+}
+
+// Auto skip drives whether recorded lectures jump over silence; a broken row must be
+// reported rather than quietly flipping the feature on.
+func TestGetAutoSkipEnabled(t *testing.T) {
+	tests := []struct {
+		name        string
+		settings    []UserSetting
+		wantEnabled bool
+		wantErr     bool
+	}{
+		{"no setting defaults to off", nil, false, false},
+		{"an explicit true", []UserSetting{{Type: AutoSkip, Value: `{"enabled":true}`}}, true, false},
+		{"an explicit false", []UserSetting{{Type: AutoSkip, Value: `{"enabled":false}`}}, false, false},
+		// An object without the field decodes fine and leaves the zero value.
+		{"an empty object is off", []UserSetting{{Type: AutoSkip, Value: `{}`}}, false, false},
+		{"malformed json is an error and off", []UserSetting{{Type: AutoSkip, Value: `{"enabled":`}}, false, true},
+		{"an empty value is an error and off", []UserSetting{{Type: AutoSkip, Value: ``}}, false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := (&User{Settings: tt.settings}).GetAutoSkipEnabled()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetAutoSkipEnabled error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got.Enabled != tt.wantEnabled {
+				t.Errorf("GetAutoSkipEnabled = %v, want %v", got.Enabled, tt.wantEnabled)
+			}
+		})
+	}
+}
+
+// The cool down exists so a display name cannot be churned to impersonate someone; it
+// is measured from the setting row's UpdatedAt.
+func TestPreferredNameChangeAllowed(t *testing.T) {
+	const threeMonths = time.Hour * 24 * 30 * 3
+
+	tests := []struct {
+		name     string
+		settings []UserSetting
+		want     bool
+	}{
+		{"no preferred name was ever set", nil, true},
+		{
+			"a name set just now is locked",
+			[]UserSetting{{Model: gorm.Model{UpdatedAt: time.Now()}, Type: PreferredName, Value: "Ada"}},
+			false,
+		},
+		{
+			"a name set four months ago may be changed",
+			[]UserSetting{{Model: gorm.Model{UpdatedAt: time.Now().Add(-threeMonths - time.Hour)}, Type: PreferredName, Value: "Ada"}},
+			true,
+		},
+		{
+			"a different setting changed recently does not lock the name",
+			[]UserSetting{{Model: gorm.Model{UpdatedAt: time.Now()}, Type: Greeting, Value: "Hi"}},
+			true,
+		},
+		// A row loaded without timestamps (or built in memory) reads as very old and
+		// therefore unlocks the name; worth knowing before trusting this as a guard.
+		{
+			"a row with no timestamp is treated as long past",
+			[]UserSetting{{Type: PreferredName, Value: "Ada"}},
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := (&User{Settings: tt.settings}).PreferredNameChangeAllowed(); got != tt.want {
+				t.Errorf("PreferredNameChangeAllowed = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// courseIDs makes the semester assertions order independent; CoursesForSemester builds
+// its result from a map, so its order is not defined.
+func courseIDs(courses []Course) map[uint]bool {
+	ids := make(map[uint]bool, len(courses))
+	for _, c := range courses {
+		ids[c.ID] = true
+	}
+	return ids
+}
+
+func assertCourseIDs(t *testing.T, got []Course, want ...uint) {
+	t.Helper()
+	ids := courseIDs(got)
+	if len(ids) != len(got) {
+		t.Errorf("result contains duplicate courses: %v", got)
+	}
+	if len(ids) != len(want) {
+		t.Fatalf("got course ids %v, want %v", ids, want)
+	}
+	for _, id := range want {
+		if !ids[id] {
+			t.Fatalf("got course ids %v, want %v", ids, want)
+		}
+	}
+}
+
+func semesterCourse(id uint, year int, term string) Course {
+	return Course{Model: gorm.Model{ID: id}, Year: year, TeachingTerm: term}
+}
+
+// The semester pickers feed the "my courses" page; a course landing in the wrong
+// semester either hides a running course or resurrects an old one.
+func TestCoursesForSemester(t *testing.T) {
+	shared := semesterCourse(1, 2023, "W")
+	u := &User{
+		Model: gorm.Model{ID: 1},
+		Role:  StudentType,
+		Courses: []Course{
+			shared,
+			semesterCourse(2, 2023, "W"),
+			semesterCourse(3, 2023, "S"),
+			semesterCourse(4, 2024, "W"),
+		},
+		AdministeredCourses: []Course{
+			shared, // also enrolled: must appear once, not twice
+			semesterCourse(5, 2023, "W"),
+		},
+	}
+
+	t.Run("enrolled and administered courses are merged without duplicates", func(t *testing.T) {
+		assertCourseIDs(t, u.CoursesForSemester(2023, "W"), 1, 2, 5)
+	})
+
+	// The term is matched exactly, so the same year in the other term must not leak.
+	t.Run("the other term of the same year is excluded", func(t *testing.T) {
+		assertCourseIDs(t, u.CoursesForSemester(2023, "S"), 3)
+	})
+
+	t.Run("a semester with nothing returns nothing", func(t *testing.T) {
+		assertCourseIDs(t, u.CoursesForSemester(2022, "S"))
+	})
+}
+
+func TestAdministeredCoursesForSemesters(t *testing.T) {
+	u := &User{
+		Model: gorm.Model{ID: 1},
+		Role:  LecturerType,
+		AdministeredCourses: []Course{
+			semesterCourse(1, 2023, "S"),
+			semesterCourse(2, 2023, "W"),
+			semesterCourse(3, 2024, "S"),
+		},
+	}
+
+	t.Run("only the listed semesters are returned", func(t *testing.T) {
+		got := u.AdministeredCoursesForSemesters([]Semester{{Year: 2023, TeachingTerm: "S"}, {Year: 2024, TeachingTerm: "S"}})
+		assertCourseIDs(t, got, 1, 3)
+	})
+
+	// The list is matched element-wise, not as a range: a year alone selects nothing.
+	t.Run("an empty semester list returns an empty slice", func(t *testing.T) {
+		got := u.AdministeredCoursesForSemesters(nil)
+		if got == nil {
+			t.Error("got nil, want an empty slice so callers can range and marshal it")
+		}
+		assertCourseIDs(t, got)
+	})
+}
+
+// The range endpoints are inclusive, and within a year S comes before W; both are easy
+// to get backwards and would silently drop a semester from the course list.
+func TestAdministeredCoursesBetweenSemesters(t *testing.T) {
+	u := &User{
+		Model: gorm.Model{ID: 1},
+		Role:  LecturerType,
+		AdministeredCourses: []Course{
+			semesterCourse(1, 2022, "W"),
+			semesterCourse(2, 2023, "S"),
+			semesterCourse(3, 2023, "W"),
+			semesterCourse(4, 2024, "S"),
+		},
+	}
+
+	tests := []struct {
+		name  string
+		first Semester
+		last  Semester
+		want  []uint
+	}{
+		{
+			"both endpoints are included",
+			Semester{Year: 2022, TeachingTerm: "W"}, Semester{Year: 2024, TeachingTerm: "S"},
+			[]uint{1, 2, 3, 4},
+		},
+		{
+			"summer sorts before winter inside a year",
+			Semester{Year: 2023, TeachingTerm: "W"}, Semester{Year: 2024, TeachingTerm: "S"},
+			[]uint{3, 4},
+		},
+		{
+			"a range ending in summer excludes that year's winter",
+			Semester{Year: 2022, TeachingTerm: "W"}, Semester{Year: 2023, TeachingTerm: "S"},
+			[]uint{1, 2},
+		},
+		{
+			"a single semester range matches only that semester",
+			Semester{Year: 2023, TeachingTerm: "S"}, Semester{Year: 2023, TeachingTerm: "S"},
+			[]uint{2},
+		},
+		{
+			"a range before everything is empty",
+			Semester{Year: 2010, TeachingTerm: "S"}, Semester{Year: 2011, TeachingTerm: "W"},
+			nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertCourseIDs(t, u.AdministeredCoursesBetweenSemesters(tt.first, tt.last), tt.want...)
+		})
+	}
+}
+
+// These two power the "courses I attend" list, which must not repeat courses already
+// shown as "courses I teach".
+func TestCoursesWithoutAdministeredCourses(t *testing.T) {
+	both := semesterCourse(1, 2023, "W")
+	u := &User{
+		Model: gorm.Model{ID: 1},
+		Role:  LecturerType,
+		Courses: []Course{
+			both,
+			semesterCourse(2, 2023, "W"),
+			semesterCourse(3, 2023, "S"),
+		},
+		AdministeredCourses: []Course{both},
+	}
+
+	t.Run("a course that is also administered is dropped", func(t *testing.T) {
+		got := u.CoursesForSemestersWithoutAdministeredCourses([]Semester{{Year: 2023, TeachingTerm: "W"}})
+		assertCourseIDs(t, got, 2)
+	})
+
+	t.Run("the same holds over a semester range", func(t *testing.T) {
+		got := u.CoursesBetweenSemestersWithoutAdministeredCourses(
+			Semester{Year: 2023, TeachingTerm: "S"}, Semester{Year: 2023, TeachingTerm: "W"})
+		assertCourseIDs(t, got, 2, 3)
+	})
+
+	// The exclusion goes through IsAdminOfCourse, which is true for every course when
+	// the caller is a server admin, so an admin's attended-course list comes back
+	// empty. Surprising, but pinned as the current behaviour.
+	t.Run("an admin sees none of their enrolled courses here", func(t *testing.T) {
+		admin := &User{Model: gorm.Model{ID: 2}, Role: AdminType, Courses: u.Courses}
+		assertCourseIDs(t, admin.CoursesForSemestersWithoutAdministeredCourses([]Semester{{Year: 2023, TeachingTerm: "W"}}))
+	})
+
+	t.Run("both return an empty slice rather than nil", func(t *testing.T) {
+		empty := &User{Model: gorm.Model{ID: 3}}
+		if empty.CoursesForSemestersWithoutAdministeredCourses(nil) == nil {
+			t.Error("CoursesForSemestersWithoutAdministeredCourses returned nil")
+		}
+		if empty.CoursesBetweenSemestersWithoutAdministeredCourses(Semester{}, Semester{}) == nil {
+			t.Error("CoursesBetweenSemestersWithoutAdministeredCourses returned nil")
+		}
+	})
+}
+
+// The magic year 1234 marks the demo course created for new lecturers; matching it too
+// loosely would hide the onboarding prompt from everyone.
+func TestHasTestCourse(t *testing.T) {
+	tests := []struct {
+		name string
+		user *User
+		want bool
+	}{
+		{"no administered courses", &User{}, false},
+		{"an administered course in year 1234", &User{AdministeredCourses: []Course{semesterCourse(1, 1234, "W")}}, true},
+		{"a real course only", &User{AdministeredCourses: []Course{semesterCourse(1, 2023, "W")}}, false},
+		// Only the administered list counts: being enrolled in the demo course is not
+		// the same as owning one.
+		{"the test course is only enrolled, not administered", &User{Courses: []Course{semesterCourse(1, 1234, "W")}}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.user.HasTestCourse(); got != tt.want {
+				t.Errorf("HasTestCourse = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// GetLoginString labels audit entries and the admin user list, where an empty label
+// would make an action untraceable.
+func TestGetLoginString(t *testing.T) {
+	tests := []struct {
+		name string
+		user *User
+		want string
+	}{
+		{"a nil user is the system", nil, "- System -"},
+		{"an email wins over the lrz id", &User{Email: sql.NullString{String: "a@b.de", Valid: true}, LrzID: "ab12cde"}, "a@b.de"},
+		{"the lrz id is used without an email", &User{LrzID: "ab12cde"}, "ab12cde"},
+		// Valid is not consulted, only the string, so an invalid-but-populated
+		// NullString is still used as the login.
+		{"an invalid null string with content is still used", &User{Email: sql.NullString{String: "a@b.de"}, LrzID: "ab12cde"}, "a@b.de"},
+		{"a user with neither has no label", &User{}, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.user.GetLoginString(); got != tt.want {
+				t.Errorf("GetLoginString = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// BeforeCreate is the only guard on the varchar(80) name column, and it also decides
+// whether a whitespace-only name counts as empty.
+func TestUserBeforeCreate(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		wantName string
+		wantErr  error
+	}{
+		{"a normal name is kept", "Ada", "Ada", nil},
+		{"surrounding whitespace is trimmed", "  Ada  ", "Ada", nil},
+		{"a whitespace only name is empty", "   ", "", ErrUsernameNoText},
+		{"an empty name is rejected", "", "", ErrUsernameNoText},
+		{"a name at the limit is accepted", strings.Repeat("a", MaxUsernameLength), strings.Repeat("a", MaxUsernameLength), nil},
+		// The limit is bytes, not runes, so a name of 80 multi-byte characters is
+		// rejected even though the column counts characters.
+		{"a name one over the limit is rejected", strings.Repeat("a", MaxUsernameLength+1), "", ErrUsernameTooLong},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := &User{Name: tt.in}
+			err := u.BeforeCreate(nil)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("BeforeCreate error = %v, want %v", err, tt.wantErr)
+			}
+			if err == nil && u.Name != tt.wantName {
+				t.Errorf("Name = %q, want %q", u.Name, tt.wantName)
+			}
+		})
+	}
+}
+
+// argon2.Version is baked into every stored hash; if the library ever bumps it, every
+// existing password stops verifying, so the constant is pinned here as a tripwire.
+func TestArgon2VersionIsPinned(t *testing.T) {
+	if argon2.Version != 0x13 {
+		t.Errorf("argon2.Version = %#x, want 0x13; existing stored hashes will no longer decode", argon2.Version)
+	}
+}

--- a/pkg/camera/axis/axis_test.go
+++ b/pkg/camera/axis/axis_test.go
@@ -1,0 +1,267 @@
+package axis
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// recorder captures what the camera would have received, so the vendor CGI string can be
+// pinned exactly: a typo in it is invisible until someone is standing in a lecture hall.
+type recorder struct {
+	method   string
+	path     string
+	rawQuery string
+	body     string
+}
+
+// newCam starts a stand-in camera and returns a driver pointed at it. Auth is a valid
+// user:password pair because protocol.MakeAuthenticatedRequest panics on anything else.
+func newCam(t *testing.T, h http.HandlerFunc) (*AxisCam, *recorder) {
+	t.Helper()
+	rec := &recorder{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		rec.method, rec.path, rec.rawQuery, rec.body = r.Method, r.URL.Path, r.URL.RawQuery, string(b)
+		h(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	return NewAxisCam(strings.TrimPrefix(srv.URL, "http://"), "user:password"), rec
+}
+
+// offlineCam points the driver at a port that refuses connections, standing in for a
+// camera that is powered off.
+func offlineCam(t *testing.T) *AxisCam {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	srv.Close()
+	return NewAxisCam(strings.TrimPrefix(srv.URL, "http://"), "user:password")
+}
+
+func TestSetPreset(t *testing.T) {
+	// Negative and out-of-range ids are included deliberately: the driver does no
+	// validation, it formats whatever it is given straight into the CGI query.
+	tests := []struct {
+		name     string
+		presetId int
+		wantQ    string
+	}{
+		{name: "preset 1 builds the documented ptz.cgi query", presetId: 1, wantQ: "gotoserverpresetno=1&camera=1"},
+		{name: "preset 0 is passed through unchanged", presetId: 0, wantQ: "gotoserverpresetno=0&camera=1"},
+		{name: "a negative preset is not rejected", presetId: -1, wantQ: "gotoserverpresetno=-1&camera=1"},
+		{name: "an out-of-range preset is not rejected", presetId: 9999, wantQ: "gotoserverpresetno=9999&camera=1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cam, rec := newCam(t, func(w http.ResponseWriter, r *http.Request) {})
+			if err := cam.SetPreset(tt.presetId); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if rec.method != http.MethodGet {
+				t.Errorf("method = %q, want GET", rec.method)
+			}
+			if rec.path != "/axis-cgi/com/ptz.cgi" {
+				t.Errorf("path = %q, want /axis-cgi/com/ptz.cgi", rec.path)
+			}
+			if rec.rawQuery != tt.wantQ {
+				t.Errorf("query = %q, want %q", rec.rawQuery, tt.wantQ)
+			}
+		})
+	}
+
+	// BUG: the status code is discarded, so a camera answering 401 or 500 looks like a
+	// successful preset change to every caller.
+	t.Run("a failing camera is reported as success", func(t *testing.T) {
+		for _, code := range []int{http.StatusInternalServerError, http.StatusUnauthorized} {
+			cam, _ := newCam(t, func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(code) })
+			if err := cam.SetPreset(1); err != nil {
+				t.Errorf("code %d: got error %v; if status handling was added, update this test", code, err)
+			}
+		}
+	})
+
+	t.Run("an offline camera returns an error", func(t *testing.T) {
+		if err := offlineCam(t).SetPreset(1); err == nil {
+			t.Error("expected an error from an unreachable camera")
+		}
+	})
+}
+
+func TestTakeSnapshot(t *testing.T) {
+	t.Run("fetches the jpg CGI and stores the bytes under a uuid filename", func(t *testing.T) {
+		dir := t.TempDir()
+		cam, rec := newCam(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("jpegbytes"))
+		})
+
+		filename, err := cam.TakeSnapshot(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rec.path != "/axis-cgi/jpg/image.cgi" || rec.rawQuery != "compression=75" {
+			t.Errorf("requested %q?%q, want /axis-cgi/jpg/image.cgi?compression=75", rec.path, rec.rawQuery)
+		}
+		if !strings.HasSuffix(filename, ".jpg") || len(filename) != len("00000000-0000-0000-0000-000000000000.jpg") {
+			t.Errorf("filename = %q, want a uuid with a .jpg suffix", filename)
+		}
+		content, err := os.ReadFile(filepath.Join(dir, filename))
+		if err != nil {
+			t.Fatalf("reading snapshot: %v", err)
+		}
+		if string(content) != "jpegbytes" {
+			t.Errorf("stored content = %q, want %q", content, "jpegbytes")
+		}
+	})
+
+	// An empty or error body is still written to disk: the driver never inspects it.
+	t.Run("an empty body still produces a file and no error", func(t *testing.T) {
+		dir := t.TempDir()
+		cam, _ := newCam(t, func(w http.ResponseWriter, r *http.Request) {})
+		filename, err := cam.TakeSnapshot(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		info, err := os.Stat(filepath.Join(dir, filename))
+		if err != nil {
+			t.Fatalf("stat snapshot: %v", err)
+		}
+		if info.Size() != 0 {
+			t.Errorf("size = %d, want 0", info.Size())
+		}
+	})
+
+	t.Run("an unwritable output directory returns an error and no filename", func(t *testing.T) {
+		cam, _ := newCam(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("jpegbytes"))
+		})
+		filename, err := cam.TakeSnapshot(filepath.Join(t.TempDir(), "missing"))
+		if err == nil {
+			t.Fatal("expected an error writing into a missing directory")
+		}
+		if filename != "" {
+			t.Errorf("filename = %q, want empty on error", filename)
+		}
+	})
+
+	t.Run("an offline camera returns an error", func(t *testing.T) {
+		if _, err := offlineCam(t).TakeSnapshot(t.TempDir()); err == nil {
+			t.Error("expected an error from an unreachable camera")
+		}
+	})
+}
+
+func TestGetPresets(t *testing.T) {
+	t.Run("posts the param.cgi list action", func(t *testing.T) {
+		cam, rec := newCam(t, func(w http.ResponseWriter, r *http.Request) {})
+		if _, err := cam.GetPresets(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rec.method != http.MethodPost {
+			t.Errorf("method = %q, want POST", rec.method)
+		}
+		if rec.path != "/axis-cgi/param.cgi" {
+			t.Errorf("path = %q, want /axis-cgi/param.cgi", rec.path)
+		}
+		if want := "action=list&group=root.PTZ.Preset.P0.Position.*.Name"; rec.body != want {
+			t.Errorf("body = %q, want %q", rec.body, want)
+		}
+	})
+
+	// The response shape is the vendor's, so a well-formed sample is parsed line by line.
+	tests := []struct {
+		name      string
+		body      string
+		wantNames []string
+		wantIds   []int
+		wantErr   bool
+	}{
+		{
+			name:      "a well-formed listing yields one preset per line",
+			body:      "root.PTZ.Preset.P0.Position.P1.Name=Tafel\nroot.PTZ.Preset.P0.Position.P2.Name=Publikum\n",
+			wantNames: []string{"Tafel", "Publikum"},
+			wantIds:   []int{1, 2},
+		},
+		{
+			name:      "a listing without a trailing newline is still parsed",
+			body:      "root.PTZ.Preset.P0.Position.P3.Name=Dozent",
+			wantNames: []string{"Dozent"},
+			wantIds:   []int{3},
+		},
+		{
+			name: "an empty body yields no presets and no error",
+			body: "",
+		},
+		{
+			name: "a body of blank lines yields no presets",
+			body: "\n\n\n",
+		},
+		{
+			name:    "a line with the wrong number of dotted segments is rejected",
+			body:    "root.PTZ.Name=Tafel\n",
+			wantErr: true,
+		},
+		{
+			name:    "a non-numeric preset index is rejected",
+			body:    "root.PTZ.Preset.P0.Position.Pxx.Name=Tafel\n",
+			wantErr: true,
+		},
+		{
+			// A camera answering with an error page rather than key=value: the status is
+			// discarded upstream, so this body is all the driver sees.
+			name: "an HTML error page yields no presets rather than an error",
+			body: "<html><head><title>401 Unauthorized</title></head></html>",
+		},
+		{
+			// Two "=" make the split length 3, so the line is skipped silently.
+			name: "a line with two equals signs is skipped",
+			body: "root.PTZ.Preset.P0.Position.P1.Name=Tafel=Extra\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cam, _ := newCam(t, func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(tt.body))
+			})
+			presets, err := cam.GetPresets()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got presets %v", presets)
+				}
+				if presets != nil {
+					t.Errorf("presets = %v, want nil alongside the error", presets)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(presets) != len(tt.wantNames) {
+				t.Fatalf("got %d presets, want %d (%v)", len(presets), len(tt.wantNames), presets)
+			}
+			for i := range presets {
+				if presets[i].Name != tt.wantNames[i] {
+					t.Errorf("preset %d name = %q, want %q", i, presets[i].Name, tt.wantNames[i])
+				}
+				if presets[i].PresetID != tt.wantIds[i] {
+					t.Errorf("preset %d id = %d, want %d", i, presets[i].PresetID, tt.wantIds[i])
+				}
+			}
+		})
+	}
+
+	t.Run("an offline camera returns an error and no presets", func(t *testing.T) {
+		presets, err := offlineCam(t).GetPresets()
+		if err == nil {
+			t.Error("expected an error from an unreachable camera")
+		}
+		if presets != nil {
+			t.Errorf("presets = %v, want nil", presets)
+		}
+	})
+}

--- a/pkg/camera/controler_test.go
+++ b/pkg/camera/controler_test.go
@@ -1,0 +1,114 @@
+package camera
+
+import (
+	"testing"
+
+	"github.com/TUM-Dev/gocast/model"
+	"github.com/TUM-Dev/gocast/pkg/camera/axis"
+	"github.com/TUM-Dev/gocast/pkg/camera/panasonic"
+	"github.com/TUM-Dev/gocast/pkg/camera/sony"
+)
+
+// The camera type stored on a lecture hall decides which vendor protocol is spoken, so
+// each mapping is pinned: picking the wrong driver leaves an unusable camera in a hall.
+func TestServiceFor(t *testing.T) {
+	auths := map[model.CameraType]string{
+		model.Axis:         "axisuser:axispass",
+		model.Panasonic:    "panauser:panapass",
+		model.Sony_SRG_A40: "sonyuser:sonypass",
+	}
+	s := NewService(auths)
+
+	tests := []struct {
+		name       string
+		cameraType model.CameraType
+		assert     func(t *testing.T, c Cam)
+	}{
+		{
+			name:       "an Axis lecture hall gets the Axis driver with its credentials",
+			cameraType: model.Axis,
+			assert: func(t *testing.T, c Cam) {
+				cam, ok := c.(*axis.AxisCam)
+				if !ok {
+					t.Fatalf("got %T, want *axis.AxisCam", c)
+				}
+				if cam.Ip != "10.0.0.1" || cam.Auth != "axisuser:axispass" {
+					t.Errorf("got (%q, %q), want (10.0.0.1, axisuser:axispass)", cam.Ip, cam.Auth)
+				}
+			},
+		},
+		{
+			name:       "a Panasonic lecture hall gets the Panasonic driver",
+			cameraType: model.Panasonic,
+			assert: func(t *testing.T, c Cam) {
+				cam, ok := c.(*panasonic.PanasonicCam)
+				if !ok {
+					t.Fatalf("got %T, want *panasonic.PanasonicCam", c)
+				}
+				if cam.Auth != "panauser:panapass" {
+					t.Errorf("auth = %q, want panauser:panapass", cam.Auth)
+				}
+			},
+		},
+		{
+			name:       "a Sony lecture hall gets the Sony driver",
+			cameraType: model.Sony_SRG_A40,
+			assert: func(t *testing.T, c Cam) {
+				cam, ok := c.(*sony.SonySRG)
+				if !ok {
+					t.Fatalf("got %T, want *sony.SonySRG", c)
+				}
+				if cam.Auth != "sonyuser:sonypass" {
+					t.Errorf("auth = %q, want sonyuser:sonypass", cam.Auth)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := s.For("10.0.0.1", tt.cameraType)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			tt.assert(t, c)
+		})
+	}
+
+	// A lecture hall carrying a camera type this build does not know (a stale row, a
+	// removed vendor) must error rather than hand back a nil Cam that callers dereference.
+	t.Run("an unknown camera type errors and returns no driver", func(t *testing.T) {
+		for _, ct := range []model.CameraType{0, 99} {
+			c, err := s.For("10.0.0.1", ct)
+			if err == nil {
+				t.Errorf("type %d: expected an error", ct)
+			}
+			if c != nil {
+				t.Errorf("type %d: got driver %v, want nil", ct, c)
+			}
+		}
+	})
+
+	// BUG: a camera type with no configured credentials yields an empty auth string,
+	// which protocol.MakeAuthenticatedRequest then splits on ":" and indexes at 1 --
+	// panicking on the first request. The factory itself still succeeds.
+	t.Run("a camera type without credentials yields an empty auth rather than an error", func(t *testing.T) {
+		c, err := NewService(map[model.CameraType]string{}).For("10.0.0.1", model.Axis)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		cam, ok := c.(*axis.AxisCam)
+		if !ok {
+			t.Fatalf("got %T, want *axis.AxisCam", c)
+		}
+		if cam.Auth != "" {
+			t.Errorf("auth = %q, want empty (see BUG note)", cam.Auth)
+		}
+	})
+
+	t.Run("a nil auth map is tolerated", func(t *testing.T) {
+		if _, err := NewService(nil).For("10.0.0.1", model.Axis); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+}

--- a/pkg/camera/mock/controler_test.go
+++ b/pkg/camera/mock/controler_test.go
@@ -1,0 +1,104 @@
+package mock_camera_test
+
+import (
+	"errors"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	"github.com/TUM-Dev/gocast/model"
+	"github.com/TUM-Dev/gocast/pkg/camera"
+	mock_camera "github.com/TUM-Dev/gocast/pkg/camera/mock"
+)
+
+// The generated mock stands in for a real camera in every test that touches lecture hall
+// control. If it drifts out of sync with the interface -- a method added to Cam and not
+// regenerated -- this stops compiling, which is the cheap durable form of that check.
+var _ camera.Cam = (*mock_camera.MockCam)(nil)
+
+func TestMockCamRecordsCalls(t *testing.T) {
+	t.Run("it forwards arguments and returns the configured values", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cam := mock_camera.NewMockCam(ctrl)
+
+		wantPresets := []model.CameraPreset{{Name: "Tafel", PresetID: 1, IsDefault: true}}
+		cam.EXPECT().SetPreset(7).Return(nil)
+		cam.EXPECT().TakeSnapshot("/tmp/out").Return("snap.jpg", nil)
+		cam.EXPECT().GetPresets().Return(wantPresets, nil)
+
+		if err := cam.SetPreset(7); err != nil {
+			t.Errorf("SetPreset returned %v, want nil", err)
+		}
+		filename, err := cam.TakeSnapshot("/tmp/out")
+		if err != nil || filename != "snap.jpg" {
+			t.Errorf("TakeSnapshot = (%q, %v), want (snap.jpg, nil)", filename, err)
+		}
+		presets, err := cam.GetPresets()
+		if err != nil {
+			t.Errorf("GetPresets returned %v, want nil", err)
+		}
+		if len(presets) != 1 || presets[0].Name != "Tafel" || presets[0].PresetID != 1 {
+			t.Errorf("GetPresets = %v, want %v", presets, wantPresets)
+		}
+	})
+
+	// Error returns must survive the mock's type assertions; a mock that swallowed them
+	// would make every error-path test using it pass vacuously.
+	t.Run("it propagates errors from every method", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cam := mock_camera.NewMockCam(ctrl)
+		boom := errors.New("camera offline")
+
+		cam.EXPECT().SetPreset(gomock.Any()).Return(boom)
+		cam.EXPECT().TakeSnapshot(gomock.Any()).Return("", boom)
+		cam.EXPECT().GetPresets().Return(nil, boom)
+
+		if err := cam.SetPreset(1); !errors.Is(err, boom) {
+			t.Errorf("SetPreset error = %v, want %v", err, boom)
+		}
+		if filename, err := cam.TakeSnapshot("/tmp"); !errors.Is(err, boom) || filename != "" {
+			t.Errorf("TakeSnapshot = (%q, %v), want (\"\", %v)", filename, err, boom)
+		}
+		if presets, err := cam.GetPresets(); !errors.Is(err, boom) || presets != nil {
+			t.Errorf("GetPresets = (%v, %v), want (nil, %v)", presets, err, boom)
+		}
+	})
+
+	// A mock that accepted any argument would hide a driver called with the wrong preset,
+	// so the argument matcher is verified to actually discriminate.
+	t.Run("it distinguishes arguments", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cam := mock_camera.NewMockCam(ctrl)
+		cam.EXPECT().SetPreset(1).Return(nil)
+		cam.EXPECT().SetPreset(2).Return(errors.New("second"))
+
+		if err := cam.SetPreset(1); err != nil {
+			t.Errorf("SetPreset(1) = %v, want nil", err)
+		}
+		if err := cam.SetPreset(2); err == nil {
+			t.Error("SetPreset(2) matched the expectation for 1")
+		}
+	})
+
+	// Call counts are the other half of "records calls": an unmet expectation must fail.
+	t.Run("it reports a call that never happened", func(t *testing.T) {
+		reporter := &recordingReporter{}
+		ctrl := gomock.NewController(reporter)
+		cam := mock_camera.NewMockCam(ctrl)
+		cam.EXPECT().SetPreset(1).Return(nil)
+		ctrl.Finish()
+
+		if !reporter.failed {
+			t.Error("an unfulfilled expectation was not reported")
+		}
+	})
+}
+
+// recordingReporter captures gomock failures instead of failing the test, so the mock's
+// own reporting can be asserted.
+type recordingReporter struct {
+	failed bool
+}
+
+func (r *recordingReporter) Errorf(format string, args ...any) { r.failed = true }
+func (r *recordingReporter) Fatalf(format string, args ...any) { r.failed = true }

--- a/pkg/camera/panasonic/panasonic_test.go
+++ b/pkg/camera/panasonic/panasonic_test.go
@@ -1,0 +1,169 @@
+package panasonic
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type recorder struct {
+	method   string
+	path     string
+	rawQuery string
+}
+
+// newCam starts a stand-in camera and returns a driver pointed at it. Auth is a valid
+// user:password pair because protocol.MakeAuthenticatedRequest panics on anything else.
+func newCam(t *testing.T, h http.HandlerFunc) (PanasonicCam, *recorder) {
+	t.Helper()
+	rec := &recorder{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.method, rec.path, rec.rawQuery = r.Method, r.URL.Path, r.URL.RawQuery
+		h(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	return *NewPanasonicCam(strings.TrimPrefix(srv.URL, "http://"), "user:password"), rec
+}
+
+func offlineCam(t *testing.T) PanasonicCam {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	srv.Close()
+	return *NewPanasonicCam(strings.TrimPrefix(srv.URL, "http://"), "user:password")
+}
+
+func TestSetPreset(t *testing.T) {
+	// The driver does no range checking; negative and out-of-range ids are formatted
+	// straight into the query, which is pinned here as current behaviour.
+	tests := []struct {
+		name     string
+		presetId int
+		wantQ    string
+	}{
+		{name: "preset 1 builds the documented camctrl query", presetId: 1, wantQ: "preset=1"},
+		{name: "preset 0 (Home) is passed through", presetId: 0, wantQ: "preset=0"},
+		{name: "a negative preset is not rejected", presetId: -5, wantQ: "preset=-5"},
+		{name: "a preset beyond the camera's 100 slots is not rejected", presetId: 500, wantQ: "preset=500"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cam, rec := newCam(t, func(w http.ResponseWriter, r *http.Request) {})
+			if err := cam.SetPreset(tt.presetId); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if rec.method != http.MethodGet {
+				t.Errorf("method = %q, want GET", rec.method)
+			}
+			if rec.path != "/cgi-bin/camctrl" {
+				t.Errorf("path = %q, want /cgi-bin/camctrl", rec.path)
+			}
+			if rec.rawQuery != tt.wantQ {
+				t.Errorf("query = %q, want %q", rec.rawQuery, tt.wantQ)
+			}
+		})
+	}
+
+	// BUG: the status code is discarded, so a camera answering 401 or 500 looks like a
+	// successful preset change to every caller.
+	t.Run("a failing camera is reported as success", func(t *testing.T) {
+		for _, code := range []int{http.StatusInternalServerError, http.StatusUnauthorized} {
+			cam, _ := newCam(t, func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(code) })
+			if err := cam.SetPreset(1); err != nil {
+				t.Errorf("code %d: got error %v; if status handling was added, update this test", code, err)
+			}
+		}
+	})
+
+	t.Run("an offline camera returns an error", func(t *testing.T) {
+		if err := offlineCam(t).SetPreset(1); err == nil {
+			t.Error("expected an error from an unreachable camera")
+		}
+	})
+}
+
+func TestTakeSnapshot(t *testing.T) {
+	t.Run("fetches view.cgi and stores the bytes under a uuid filename", func(t *testing.T) {
+		dir := t.TempDir()
+		cam, rec := newCam(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("jpegbytes"))
+		})
+
+		filename, err := cam.TakeSnapshot(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rec.path != "/cgi-bin/view.cgi" || rec.rawQuery != "action=snapshot" {
+			t.Errorf("requested %q?%q, want /cgi-bin/view.cgi?action=snapshot", rec.path, rec.rawQuery)
+		}
+		if !strings.HasSuffix(filename, ".jpg") {
+			t.Errorf("filename = %q, want a .jpg suffix", filename)
+		}
+		content, err := os.ReadFile(filepath.Join(dir, filename))
+		if err != nil {
+			t.Fatalf("reading snapshot: %v", err)
+		}
+		if string(content) != "jpegbytes" {
+			t.Errorf("stored content = %q, want %q", content, "jpegbytes")
+		}
+	})
+
+	t.Run("an unwritable output directory returns an error and no filename", func(t *testing.T) {
+		cam, _ := newCam(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("jpegbytes"))
+		})
+		filename, err := cam.TakeSnapshot(filepath.Join(t.TempDir(), "missing"))
+		if err == nil {
+			t.Fatal("expected an error writing into a missing directory")
+		}
+		if filename != "" {
+			t.Errorf("filename = %q, want empty on error", filename)
+		}
+	})
+
+	t.Run("an offline camera returns an error", func(t *testing.T) {
+		if _, err := offlineCam(t).TakeSnapshot(t.TempDir()); err == nil {
+			t.Error("expected an error from an unreachable camera")
+		}
+	})
+}
+
+// GetPresets is a pure stub list on Panasonic: it never talks to the camera. The names
+// reach the admin UI verbatim, so the exact formatting is pinned.
+func TestGetPresets(t *testing.T) {
+	cam := *NewPanasonicCam("192.0.2.1", "user:password") // never dialled; asserted by the absence of a server
+
+	presets, err := cam.GetPresets()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(presets) != 10 {
+		t.Fatalf("got %d presets, want 10", len(presets))
+	}
+	if presets[0].Name != "Home" {
+		t.Errorf("preset 0 name = %q, want %q", presets[0].Name, "Home")
+	}
+	for i, p := range presets {
+		if p.PresetID != i {
+			t.Errorf("preset %d has id %d", i, p.PresetID)
+		}
+		if i == 0 {
+			continue
+		}
+		if want := fmt.Sprintf("Preset #%2d", i); p.Name != want {
+			t.Errorf("preset %d name = %q, want %q", i, p.Name, want)
+		}
+		// No preset is flagged default, unlike the Sony driver; pinned so the
+		// inconsistency is noticed if either side changes.
+		if p.IsDefault {
+			t.Errorf("preset %d is marked default", i)
+		}
+	}
+	if presets[0].IsDefault {
+		t.Error("preset 0 (Home) is marked default; it was not before")
+	}
+}

--- a/pkg/camera/protocol/protocol_test.go
+++ b/pkg/camera/protocol/protocol_test.go
@@ -1,0 +1,211 @@
+package protocol
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// closedServerURL returns a URL that is guaranteed to refuse connections: an httptest
+// server is started to claim a free loopback port, then immediately closed. This stands
+// in for a lecture-hall camera that is powered off, without ever touching a real IP.
+func closedServerURL(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+	return url
+}
+
+func TestMakeAuthenticatedRequest(t *testing.T) {
+	t.Run("a GET returns the body and status of a healthy camera", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet {
+				t.Errorf("method = %q, want GET", r.Method)
+			}
+			_, _ = w.Write([]byte("OK"))
+		}))
+		defer srv.Close()
+
+		buf, status, err := MakeAuthenticatedRequest(nil, "GET", "", srv.URL)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if status != http.StatusOK {
+			t.Errorf("status = %d, want 200", status)
+		}
+		if buf.String() != "OK" {
+			t.Errorf("body = %q, want %q", buf.String(), "OK")
+		}
+	})
+
+	t.Run("a POST forwards the body verbatim", func(t *testing.T) {
+		const want = "action=list&group=root.PTZ.Preset.P0.Position.*.Name"
+		var got string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("method = %q, want POST", r.Method)
+			}
+			b, _ := io.ReadAll(r.Body)
+			got = string(b)
+		}))
+		defer srv.Close()
+
+		if _, _, err := MakeAuthenticatedRequest(nil, "POST", want, srv.URL); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != want {
+			t.Errorf("forwarded body = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("an unsupported method is rejected before any connection is made", func(t *testing.T) {
+		buf, status, err := MakeAuthenticatedRequest(nil, "PUT", "", closedServerURL(t))
+		if err == nil {
+			t.Fatal("expected an error for an unsupported method")
+		}
+		if buf != nil {
+			t.Errorf("buffer = %v, want nil", buf)
+		}
+		if status != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400", status)
+		}
+	})
+
+	t.Run("an unparsable URL errors instead of panicking", func(t *testing.T) {
+		buf, status, err := MakeAuthenticatedRequest(nil, "GET", "", "http://%zz/broken")
+		if err == nil {
+			t.Fatal("expected an error for an unparsable URL")
+		}
+		if buf != nil || status != http.StatusBadRequest {
+			t.Errorf("got (%v, %d), want (nil, 400)", buf, status)
+		}
+	})
+
+	t.Run("a camera that is offline surfaces a transport error with status 0", func(t *testing.T) {
+		buf, status, err := MakeAuthenticatedRequest(nil, "GET", "", closedServerURL(t))
+		if err == nil {
+			t.Fatal("expected a connection error")
+		}
+		if buf != nil {
+			t.Errorf("buffer = %v, want nil", buf)
+		}
+		if status != 0 {
+			t.Errorf("status = %d, want 0", status)
+		}
+	})
+
+	// A camera answering 500 or 401 is not reported as an error here; only the status
+	// code carries that information. Callers that drop the status (every driver's
+	// SetPreset does) therefore cannot tell failure from success -- pinned so the day
+	// someone adds status handling, the affected callers are found by a failing test.
+	t.Run("a non-200 response is returned without an error", func(t *testing.T) {
+		for _, code := range []int{http.StatusInternalServerError, http.StatusUnauthorized, http.StatusNotFound} {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(code)
+				_, _ = w.Write([]byte("failure body"))
+			}))
+
+			buf, status, err := MakeAuthenticatedRequest(nil, "GET", "", srv.URL)
+			if err != nil {
+				t.Errorf("code %d: unexpected error: %v", code, err)
+			}
+			if status != code {
+				t.Errorf("status = %d, want %d", status, code)
+			}
+			if buf == nil || buf.String() != "failure body" {
+				t.Errorf("code %d: body not returned", code)
+			}
+			srv.Close()
+		}
+	})
+
+	t.Run("an empty body yields an empty buffer and no error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		defer srv.Close()
+
+		buf, status, err := MakeAuthenticatedRequest(nil, "GET", "", srv.URL)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if status != http.StatusOK {
+			t.Errorf("status = %d, want 200", status)
+		}
+		if buf == nil {
+			t.Fatal("buffer is nil for an empty body; callers dereference it")
+		}
+		if buf.Len() != 0 {
+			t.Errorf("body = %q, want empty", buf.String())
+		}
+	})
+
+	t.Run("a user:password pair still reaches a camera that does not challenge", func(t *testing.T) {
+		auth := "user:password"
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("done"))
+		}))
+		defer srv.Close()
+
+		buf, status, err := MakeAuthenticatedRequest(&auth, "GET", "", srv.URL)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if status != http.StatusOK || buf.String() != "done" {
+			t.Errorf("got (%q, %d), want (%q, 200)", buf.String(), status, "done")
+		}
+	})
+
+	// BUG: the auth string is split on ":" and index 1 is read unconditionally, so any
+	// credential without a colon panics. camera.Service.For passes "" for a camera type
+	// that has no configured credentials, which makes this reachable from configuration
+	// alone. Pinned as current behaviour, not endorsed.
+	t.Run("a credential without a colon panics", func(t *testing.T) {
+		for _, auth := range []string{"", "userwithoutcolon"} {
+			func() {
+				defer func() {
+					if recover() == nil {
+						t.Errorf("auth %q: expected a panic (see BUG note); it no longer panics -- update this test", auth)
+					}
+				}()
+				a := auth
+				_, _, _ = MakeAuthenticatedRequest(&a, "GET", "", closedServerURL(t))
+			}()
+		}
+	})
+}
+
+func TestSaveResponseBuffer(t *testing.T) {
+	t.Run("writes the response bytes to outDir/filename", func(t *testing.T) {
+		dir := t.TempDir()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("jpegbytes"))
+		}))
+		defer srv.Close()
+
+		buf, _, err := MakeAuthenticatedRequest(nil, "GET", "", srv.URL)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if err := SaveResponseBuffer(dir, "snap.jpg", buf); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		content, err := os.ReadFile(filepath.Join(dir, "snap.jpg"))
+		if err != nil {
+			t.Fatalf("reading written file: %v", err)
+		}
+		if string(content) != "jpegbytes" {
+			t.Errorf("file content = %q, want %q", content, "jpegbytes")
+		}
+	})
+
+	t.Run("a missing output directory errors instead of panicking", func(t *testing.T) {
+		err := SaveResponseBuffer(filepath.Join(t.TempDir(), "does-not-exist"), "snap.jpg", bytes.NewBufferString("ignored"))
+		if err == nil {
+			t.Error("expected an error writing into a missing directory")
+		}
+	})
+}

--- a/pkg/camera/sony/sonysrg_test.go
+++ b/pkg/camera/sony/sonysrg_test.go
@@ -1,0 +1,226 @@
+package sony
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type recorder struct {
+	mu       sync.Mutex
+	method   string
+	path     string
+	rawQuery string
+	paths    []string
+}
+
+func (r *recorder) record(req *http.Request) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.method, r.path, r.rawQuery = req.Method, req.URL.Path, req.URL.RawQuery
+	r.paths = append(r.paths, req.URL.Path)
+}
+
+// newCam starts a stand-in camera and returns a driver pointed at it. Auth is a valid
+// user:password pair because protocol.MakeAuthenticatedRequest panics on anything else.
+func newCam(t *testing.T, h http.HandlerFunc) (*SonySRG, *recorder) {
+	t.Helper()
+	rec := &recorder{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.record(r)
+		h(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	return NewSonySRG(strings.TrimPrefix(srv.URL, "http://"), "user:password"), rec
+}
+
+func offlineCam(t *testing.T) *SonySRG {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	srv.Close()
+	return NewSonySRG(strings.TrimPrefix(srv.URL, "http://"), "user:password")
+}
+
+func TestSetPreset(t *testing.T) {
+	// The driver does no range checking; the SRG-A40 supports 256 presets but nothing
+	// here enforces that, which is pinned as current behaviour.
+	tests := []struct {
+		name     string
+		presetId int
+		wantQ    string
+	}{
+		{name: "preset 1 builds the documented presetposition query", presetId: 1, wantQ: "PresetCall=1"},
+		{name: "preset 0 is passed through", presetId: 0, wantQ: "PresetCall=0"},
+		{name: "a negative preset is not rejected", presetId: -1, wantQ: "PresetCall=-1"},
+		{name: "a preset beyond the camera's 256 slots is not rejected", presetId: 1000, wantQ: "PresetCall=1000"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cam, rec := newCam(t, func(w http.ResponseWriter, r *http.Request) {})
+			if err := cam.SetPreset(tt.presetId); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if rec.method != http.MethodGet {
+				t.Errorf("method = %q, want GET", rec.method)
+			}
+			if rec.path != "/command/presetposition.cgi" {
+				t.Errorf("path = %q, want /command/presetposition.cgi", rec.path)
+			}
+			if rec.rawQuery != tt.wantQ {
+				t.Errorf("query = %q, want %q", rec.rawQuery, tt.wantQ)
+			}
+		})
+	}
+
+	// BUG: the status code is discarded, so a camera answering 401 or 500 looks like a
+	// successful preset change to every caller.
+	t.Run("a failing camera is reported as success", func(t *testing.T) {
+		for _, code := range []int{http.StatusInternalServerError, http.StatusUnauthorized} {
+			cam, _ := newCam(t, func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(code) })
+			if err := cam.SetPreset(1); err != nil {
+				t.Errorf("code %d: got error %v; if status handling was added, update this test", code, err)
+			}
+		}
+	})
+
+	t.Run("an offline camera returns an error", func(t *testing.T) {
+		if err := offlineCam(t).SetPreset(1); err == nil {
+			t.Error("expected an error from an unreachable camera")
+		}
+	})
+}
+
+func TestTakeSnapshot(t *testing.T) {
+	t.Run("fetches oneshotimage1 and stores the bytes under a uuid filename", func(t *testing.T) {
+		dir := t.TempDir()
+		cam, rec := newCam(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("jpegbytes"))
+		})
+
+		filename, err := cam.TakeSnapshot(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rec.path != "/oneshotimage1" {
+			t.Errorf("path = %q, want /oneshotimage1", rec.path)
+		}
+		if !strings.HasSuffix(filename, ".jpg") {
+			t.Errorf("filename = %q, want a .jpg suffix", filename)
+		}
+		content, err := os.ReadFile(filepath.Join(dir, filename))
+		if err != nil {
+			t.Fatalf("reading snapshot: %v", err)
+		}
+		if string(content) != "jpegbytes" {
+			t.Errorf("stored content = %q, want %q", content, "jpegbytes")
+		}
+	})
+
+	t.Run("an unwritable output directory returns an error and no filename", func(t *testing.T) {
+		cam, _ := newCam(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("jpegbytes"))
+		})
+		filename, err := cam.TakeSnapshot(filepath.Join(t.TempDir(), "missing"))
+		if err == nil {
+			t.Fatal("expected an error writing into a missing directory")
+		}
+		if filename != "" {
+			t.Errorf("filename = %q, want empty on error", filename)
+		}
+	})
+
+	t.Run("an offline camera returns an error", func(t *testing.T) {
+		if _, err := offlineCam(t).TakeSnapshot(t.TempDir()); err == nil {
+			t.Error("expected an error from an unreachable camera")
+		}
+	})
+}
+
+// GetPresets probes preset thumbnails one by one and stops at the first non-200, so the
+// stop condition is what decides how many presets a lecture hall shows.
+func TestGetPresets(t *testing.T) {
+	tests := []struct {
+		name      string
+		okUpTo    int // number of leading probes answered 200
+		failCode  int
+		wantCount int
+	}{
+		{name: "all sixteen thumbnails present yields sixteen presets", okUpTo: 16, failCode: http.StatusNotFound, wantCount: 16},
+		{name: "probing stops at the first missing thumbnail", okUpTo: 3, failCode: http.StatusNotFound, wantCount: 3},
+		{name: "no thumbnails yields no presets and no error", okUpTo: 0, failCode: http.StatusNotFound, wantCount: 0},
+		{name: "a 401 on the first probe is treated as no presets rather than an error", okUpTo: 0, failCode: http.StatusUnauthorized, wantCount: 0},
+		{name: "a 500 mid-listing truncates the list silently", okUpTo: 2, failCode: http.StatusInternalServerError, wantCount: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			seen := 0
+			cam, rec := newCam(t, func(w http.ResponseWriter, r *http.Request) {
+				seen++
+				if seen > tt.okUpTo {
+					w.WriteHeader(tt.failCode)
+					return
+				}
+				_, _ = w.Write([]byte("thumbnail"))
+			})
+
+			presets, err := cam.GetPresets()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(presets) != tt.wantCount {
+				t.Fatalf("got %d presets, want %d", len(presets), tt.wantCount)
+			}
+			for i, p := range presets {
+				if p.PresetID != i+1 {
+					t.Errorf("preset %d has id %d, want %d", i, p.PresetID, i+1)
+				}
+				if want := fmt.Sprintf("Preset %d", i+1); p.Name != want {
+					t.Errorf("preset %d name = %q, want %q", i, p.Name, want)
+				}
+				if p.IsDefault != (i == 0) {
+					t.Errorf("preset %d IsDefault = %v, want %v", i, p.IsDefault, i == 0)
+				}
+			}
+			// The thumbnail paths are one-based and pinned: an off-by-one here would
+			// silently drop or duplicate a preset in the lecture hall UI.
+			for i := 0; i < tt.wantCount; i++ {
+				if want := fmt.Sprintf("/preset/presetimg%d.jpg", i+1); rec.paths[i] != want {
+					t.Errorf("probe %d requested %q, want %q", i, rec.paths[i], want)
+				}
+			}
+		})
+	}
+
+	// An offline camera must not error out of the listing; it yields an empty list.
+	t.Run("an offline camera yields no presets and no error", func(t *testing.T) {
+		presets, err := offlineCam(t).GetPresets()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(presets) != 0 {
+			t.Errorf("got %d presets, want 0", len(presets))
+		}
+	})
+
+	// A 200 with a body that is not a JPEG is accepted: the driver only looks at the
+	// status, never at the bytes.
+	t.Run("a non-image body is still counted as a preset", func(t *testing.T) {
+		cam, _ := newCam(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("<html>not an image</html>"))
+		})
+		presets, err := cam.GetPresets()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(presets) != 16 {
+			t.Errorf("got %d presets, want 16", len(presets))
+		}
+	})
+}

--- a/tools/api-errors_test.go
+++ b/tools/api-errors_test.go
@@ -1,0 +1,168 @@
+package tools
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestRequestErrorError(t *testing.T) {
+	t.Run("reports the wrapped error", func(t *testing.T) {
+		err := RequestError{Status: http.StatusBadRequest, Err: errors.New("bad input")}
+		if got := err.Error(); got != "bad input" {
+			t.Errorf("Error() = %q, want %q", got, "bad input")
+		}
+	})
+
+	// Handlers routinely build a RequestError with only a status and a message; a nil
+	// dereference here would panic inside the error path itself.
+	t.Run("an error without a cause is empty rather than a panic", func(t *testing.T) {
+		err := RequestError{Status: http.StatusForbidden, CustomMessage: "nope"}
+		if got := err.Error(); got != "" {
+			t.Errorf("Error() = %q, want empty", got)
+		}
+	})
+
+	t.Run("satisfies the error interface by value", func(t *testing.T) {
+		var _ error = RequestError{}
+	})
+}
+
+func TestRequestErrorToResponse(t *testing.T) {
+	tests := []struct {
+		name string
+		err  RequestError
+		want gin.H
+	}{
+		{
+			name: "carries status, message and cause",
+			err:  RequestError{Status: http.StatusBadRequest, CustomMessage: "can not parse id", Err: errors.New("strconv: bad syntax")},
+			want: gin.H{"status": http.StatusBadRequest, "message": "can not parse id", "error": "strconv: bad syntax"},
+		},
+		{
+			// The internal cause must stay out of the body when there is none, so the
+			// client is not handed an empty "error" key to branch on.
+			name: "omits the error key when there is no cause",
+			err:  RequestError{Status: http.StatusForbidden, CustomMessage: "forbidden"},
+			want: gin.H{"status": http.StatusForbidden, "message": "forbidden"},
+		},
+		{
+			name: "a zero value still renders both required keys",
+			err:  RequestError{},
+			want: gin.H{"status": 0, "message": ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.err.ToResponse()
+			if len(got) != len(tt.want) {
+				t.Fatalf("keys = %v, want %v", got, tt.want)
+			}
+			for k, want := range tt.want {
+				if got[k] != want {
+					t.Errorf("%q = %v, want %v", k, got[k], want)
+				}
+			}
+		})
+	}
+}
+
+// ErrorHandler is mounted in front of the API routes, so both error shapes and the
+// no-error case are pinned end to end.
+func TestErrorHandler(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("renders a RequestError with its own status and body", func(t *testing.T) {
+		rec := serveThroughErrorHandler(t, func(c *gin.Context) {
+			_ = c.Error(RequestError{
+				Status:        http.StatusNotFound,
+				CustomMessage: "no such stream",
+				Err:           errors.New("record not found"),
+			})
+		})
+
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
+		}
+		var body map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+			t.Fatalf("body %q is not JSON: %v", rec.Body.String(), err)
+		}
+		want := map[string]any{"status": float64(http.StatusNotFound), "message": "no such stream", "error": "record not found"}
+		for k, v := range want {
+			if body[k] != v {
+				t.Errorf("body[%q] = %v, want %v", k, body[k], v)
+			}
+		}
+	})
+
+	t.Run("turns a plain error into a 500 with the bare message", func(t *testing.T) {
+		rec := serveThroughErrorHandler(t, func(c *gin.Context) {
+			_ = c.Error(errors.New("database exploded"))
+		})
+
+		if rec.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+		}
+		// The default branch serialises the raw message as a bare JSON string, not an
+		// object, so clients cannot parse both shapes the same way.
+		if got := rec.Body.String(); got != `"database exploded"` {
+			t.Errorf("body = %q, want %q", got, `"database exploded"`)
+		}
+	})
+
+	t.Run("only the first error decides the response", func(t *testing.T) {
+		rec := serveThroughErrorHandler(t, func(c *gin.Context) {
+			_ = c.Error(RequestError{Status: http.StatusTeapot, CustomMessage: "first"})
+			_ = c.Error(errors.New("second"))
+		})
+
+		if rec.Code != http.StatusTeapot {
+			t.Errorf("status = %d, want %d", rec.Code, http.StatusTeapot)
+		}
+	})
+
+	t.Run("leaves a successful response alone", func(t *testing.T) {
+		rec := serveThroughErrorHandler(t, func(c *gin.Context) {
+			c.String(http.StatusOK, "fine")
+		})
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+		}
+		if got := rec.Body.String(); got != "fine" {
+			t.Errorf("body = %q, want %q", got, "fine")
+		}
+	})
+
+	// A RequestError pushed by a handler that already wrote a body must not have its
+	// status silently applied on top of the committed one.
+	t.Run("an already written response keeps its status", func(t *testing.T) {
+		rec := serveThroughErrorHandler(t, func(c *gin.Context) {
+			c.String(http.StatusOK, "partial")
+			_ = c.Error(RequestError{Status: http.StatusBadRequest, CustomMessage: "too late"})
+		})
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+		}
+	})
+}
+
+// serveThroughErrorHandler runs one request through ErrorHandler and the given handler.
+func serveThroughErrorHandler(t *testing.T, handler gin.HandlerFunc) *httptest.ResponseRecorder {
+	t.Helper()
+
+	router := gin.New()
+	router.Use(ErrorHandler)
+	router.GET("/api/thing", handler)
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/thing", nil))
+	return rec
+}

--- a/tools/branding_test.go
+++ b/tools/branding_test.go
@@ -1,0 +1,105 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The defaults are what the site header renders whenever branding.yaml is absent, which
+// is the normal case for a fresh deployment, so a blank field here ships a blank header.
+func TestGetDefaultBranding(t *testing.T) {
+	b := getDefaultBranding()
+
+	if b.Title != "TUM-Live" {
+		t.Errorf("Title = %q, want %q", b.Title, "TUM-Live")
+	}
+	if b.Description == "" {
+		t.Error("Description is empty, want the default description")
+	}
+}
+
+// InitBranding writes the package global BrandingCfg and reads a config file from the
+// working directory, so both are restored around every case.
+func TestInitBranding(t *testing.T) {
+	t.Run("falls back to the defaults when there is no branding file", func(t *testing.T) {
+		withIsolatedBrandingEnv(t)
+
+		InitBranding()
+
+		if BrandingCfg != getDefaultBranding() {
+			t.Errorf("BrandingCfg = %+v, want the defaults", BrandingCfg)
+		}
+	})
+
+	t.Run("takes title and description from branding.yaml", func(t *testing.T) {
+		dir := withIsolatedBrandingEnv(t)
+		writeBrandingYAML(t, dir, "title: GoCast\ndescription: lecture streaming\n")
+
+		InitBranding()
+
+		if BrandingCfg.Title != "GoCast" {
+			t.Errorf("Title = %q, want %q", BrandingCfg.Title, "GoCast")
+		}
+		if BrandingCfg.Description != "lecture streaming" {
+			t.Errorf("Description = %q, want %q", BrandingCfg.Description, "lecture streaming")
+		}
+	})
+
+	// A partial file must not blank out the fields it leaves unset: unmarshalling runs
+	// on top of the defaults rather than on a zero value.
+	t.Run("a partial file keeps the default for the fields it omits", func(t *testing.T) {
+		dir := withIsolatedBrandingEnv(t)
+		writeBrandingYAML(t, dir, "title: GoCast\n")
+
+		InitBranding()
+
+		if BrandingCfg.Title != "GoCast" {
+			t.Errorf("Title = %q, want %q", BrandingCfg.Title, "GoCast")
+		}
+		if BrandingCfg.Description != getDefaultBranding().Description {
+			t.Errorf("Description = %q, want the default", BrandingCfg.Description)
+		}
+	})
+
+	t.Run("an empty file leaves the defaults in place", func(t *testing.T) {
+		dir := withIsolatedBrandingEnv(t)
+		writeBrandingYAML(t, dir, "")
+
+		InitBranding()
+
+		if BrandingCfg != getDefaultBranding() {
+			t.Errorf("BrandingCfg = %+v, want the defaults", BrandingCfg)
+		}
+	})
+}
+
+// withIsolatedBrandingEnv points every search path InitBranding consults at a temporary
+// directory and restores BrandingCfg afterwards, so nothing here reaches the real
+// machine or leaks into the rest of the package.
+func withIsolatedBrandingEnv(t *testing.T) string {
+	t.Helper()
+
+	// InitBranding also searches /etc/TUM-Live, which a test cannot isolate.
+	if _, err := os.Stat("/etc/TUM-Live/branding.yaml"); err == nil {
+		t.Skip("a machine-wide /etc/TUM-Live/branding.yaml would win over the test fixture")
+	}
+
+	dir := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Chdir(dir)
+
+	before := BrandingCfg
+	t.Cleanup(func() { BrandingCfg = before })
+
+	return dir
+}
+
+func writeBrandingYAML(t *testing.T, dir, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(filepath.Join(dir, "branding.yaml"), []byte(content), 0o600); err != nil {
+		t.Fatalf("writing branding.yaml: %v", err)
+	}
+}

--- a/tools/canonical_test.go
+++ b/tools/canonical_test.go
@@ -1,0 +1,129 @@
+package tools
+
+import "testing"
+
+// CanonicalURL feeds <link rel="canonical"> and the share links, so every method is
+// pinned against the two shapes the deployment config actually takes: a bare origin and
+// an origin with a path prefix, each with and without a trailing slash.
+func TestCanonicalURL(t *testing.T) {
+	tests := []struct {
+		name string
+		base string
+		got  func(CanonicalURL) string
+		want string
+	}{
+		{
+			// path.Clean collapses the "//" in the scheme. Every method below inherits
+			// this, so the canonical tags and share links ship a scheme-mangled URL.
+			name: "a bare origin loses a slash from its scheme once anything is joined",
+			base: "https://live.rbg.tum.de",
+			got:  func(c CanonicalURL) string { return c.Login() },
+			want: "https:/live.rbg.tum.de/login",
+		},
+		{
+			name: "Root hands back the configured base untouched",
+			base: "https://live.rbg.tum.de",
+			got:  CanonicalURL.Root,
+			want: "https://live.rbg.tum.de",
+		},
+		{
+			name: "Root keeps a trailing slash, unlike every other method",
+			base: "https://live.rbg.tum.de/",
+			got:  CanonicalURL.Root,
+			want: "https://live.rbg.tum.de/",
+		},
+		{
+			name: "a trailing slash on the base does not double up",
+			base: "https://live.rbg.tum.de/",
+			got:  func(c CanonicalURL) string { return c.Login() },
+			want: "https:/live.rbg.tum.de/login",
+		},
+		{
+			name: "a base with a path prefix keeps the prefix",
+			base: "https://example.org/tum",
+			got:  func(c CanonicalURL) string { return c.Login() },
+			want: "https:/example.org/tum/login",
+		},
+		{
+			// An unset canonicalURL in the config yields a relative path rather than
+			// an absolute URL, which is not a valid canonical link.
+			name: "an empty base produces a bare relative path",
+			base: "",
+			got:  func(c CanonicalURL) string { return c.Login() },
+			want: "login",
+		},
+		{
+			name: "Course joins year, term and slug",
+			base: "https://live.rbg.tum.de",
+			got:  func(c CanonicalURL) string { return c.Course(2023, "W", "eidi") },
+			want: "https:/live.rbg.tum.de/course/2023/W/eidi",
+		},
+		{
+			name: "Course renders a negative year rather than rejecting it",
+			base: "https://live.rbg.tum.de",
+			got:  func(c CanonicalURL) string { return c.Course(-1, "S", "eidi") },
+			want: "https:/live.rbg.tum.de/course/-1/S/eidi",
+		},
+		{
+			// Slugs come from user-editable course settings, so what a separator in one
+			// does to the resulting URL is pinned deliberately.
+			name: "a slug containing a slash becomes an extra path segment",
+			base: "https://live.rbg.tum.de",
+			got:  func(c CanonicalURL) string { return c.Course(2023, "W", "ei/di") },
+			want: "https:/live.rbg.tum.de/course/2023/W/ei/di",
+		},
+		{
+			// path.Clean resolves the traversal instead of leaving it in the link, so a
+			// crafted slug can point the canonical tag at an unrelated path.
+			name: "a slug with .. is cleaned away and climbs out of the course path",
+			base: "https://live.rbg.tum.de",
+			got:  func(c CanonicalURL) string { return c.Course(2023, "W", "../../../login") },
+			want: "https:/live.rbg.tum.de/login",
+		},
+		{
+			name: "enough .. segments collapse the whole URL to the current directory",
+			base: "https://live.rbg.tum.de",
+			got:  func(c CanonicalURL) string { return c.Course(2023, "W", "../../../../..") },
+			want: ".",
+		},
+		{
+			name: "Stream joins slug, id and version",
+			base: "https://live.rbg.tum.de",
+			got:  func(c CanonicalURL) string { return c.Stream("eidi", 42, "CAM") },
+			want: "https:/live.rbg.tum.de/w/eidi/42/CAM",
+		},
+		{
+			name: "Stream drops an empty version instead of leaving a trailing slash",
+			base: "https://live.rbg.tum.de",
+			got:  func(c CanonicalURL) string { return c.Stream("eidi", 42, "") },
+			want: "https:/live.rbg.tum.de/w/eidi/42",
+		},
+		{
+			// The id is a uint but is narrowed through int before formatting.
+			name: "Stream formats a large id without wrapping",
+			base: "https://live.rbg.tum.de",
+			got:  func(c CanonicalURL) string { return c.Stream("eidi", 4294967295, "PRES") },
+			want: "https:/live.rbg.tum.de/w/eidi/4294967295/PRES",
+		},
+		{
+			name: "Info appends the page name",
+			base: "https://live.rbg.tum.de",
+			got:  func(c CanonicalURL) string { return c.Info("imprint") },
+			want: "https:/live.rbg.tum.de/imprint",
+		},
+		{
+			name: "Info with an empty name falls back to the cleaned origin",
+			base: "https://live.rbg.tum.de",
+			got:  func(c CanonicalURL) string { return c.Info("") },
+			want: "https:/live.rbg.tum.de",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.got(NewCanonicalURL(tt.base)); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/tools/cron_test.go
+++ b/tools/cron_test.go
@@ -1,0 +1,166 @@
+package tools
+
+import (
+	"sort"
+	"testing"
+)
+
+// newTestCronService builds a CronService without touching the global Cron, so these
+// tests cannot leak state into the rest of the package.
+func newTestCronService(t *testing.T) *CronService {
+	t.Helper()
+
+	before := Cron
+	InitCronService()
+	c := Cron
+	t.Cleanup(func() { Cron = before })
+	return c
+}
+
+func TestCronServiceAddFunc(t *testing.T) {
+	t.Run("registers a job under a valid spec", func(t *testing.T) {
+		c := newTestCronService(t)
+
+		if err := c.AddFunc("collect", func() {}, "0 0 * * *"); err != nil {
+			t.Fatalf("AddFunc returned %v, want nil", err)
+		}
+		if got := c.ListCronJobs(); len(got) != 1 || got[0] != "collect" {
+			t.Errorf("ListCronJobs() = %v, want [collect]", got)
+		}
+	})
+
+	t.Run("accepts a descriptor spec", func(t *testing.T) {
+		c := newTestCronService(t)
+
+		if err := c.AddFunc("hourly", func() {}, "@every 1h"); err != nil {
+			t.Errorf("AddFunc returned %v, want nil", err)
+		}
+	})
+
+	// An invalid spec is a config typo at startup. The scheduler rejects it, but the
+	// name is registered before the spec is parsed, so the job stays reachable by name
+	// even though it will never fire on a schedule.
+	t.Run("an invalid spec errors yet still leaves the job listed", func(t *testing.T) {
+		c := newTestCronService(t)
+
+		if err := c.AddFunc("broken", func() {}, "not a cron spec"); err == nil {
+			t.Fatal("AddFunc returned nil, want an error")
+		}
+		if got := c.ListCronJobs(); len(got) != 1 || got[0] != "broken" {
+			t.Errorf("ListCronJobs() = %v, want [broken]", got)
+		}
+	})
+
+	t.Run("re-adding a name replaces the function it resolves to", func(t *testing.T) {
+		c := newTestCronService(t)
+
+		ran := make(chan string, 2)
+		for _, which := range []string{"first", "second"} {
+			if err := c.AddFunc("job", func() { ran <- which }, "0 0 * * *"); err != nil {
+				t.Fatalf("AddFunc(%q) returned %v", which, err)
+			}
+		}
+
+		c.RunJob("job")
+		if got := <-ran; got != "second" {
+			t.Errorf("ran %q, want %q", got, "second")
+		}
+		if got := c.ListCronJobs(); len(got) != 1 {
+			t.Errorf("ListCronJobs() = %v, want a single entry", got)
+		}
+	})
+}
+
+func TestCronServiceListCronJobs(t *testing.T) {
+	t.Run("is empty before anything is added", func(t *testing.T) {
+		c := newTestCronService(t)
+
+		if got := c.ListCronJobs(); len(got) != 0 {
+			t.Errorf("ListCronJobs() = %v, want empty", got)
+		}
+	})
+
+	t.Run("lists every registered name", func(t *testing.T) {
+		c := newTestCronService(t)
+
+		for _, name := range []string{"a", "b", "c"} {
+			if err := c.AddFunc(name, func() {}, "0 0 * * *"); err != nil {
+				t.Fatalf("AddFunc(%q) returned %v", name, err)
+			}
+		}
+
+		got := c.ListCronJobs()
+		sort.Strings(got)
+		want := []string{"a", "b", "c"}
+		if len(got) != len(want) {
+			t.Fatalf("ListCronJobs() = %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("ListCronJobs() = %v, want %v", got, want)
+			}
+		}
+	})
+}
+
+// RunJob backs an admin route that passes the name straight from the request, so an
+// unknown name must be a no-op rather than a panic, and the scheduler need not be
+// running for a manual trigger to work.
+func TestCronServiceRunJob(t *testing.T) {
+	t.Run("runs a registered job without starting the scheduler", func(t *testing.T) {
+		c := newTestCronService(t)
+
+		ran := make(chan struct{})
+		if err := c.AddFunc("collect", func() { close(ran) }, "0 0 * * *"); err != nil {
+			t.Fatalf("AddFunc returned %v", err)
+		}
+
+		c.RunJob("collect")
+		<-ran
+	})
+
+	t.Run("ignores an unknown name", func(t *testing.T) {
+		c := newTestCronService(t)
+
+		ran := make(chan struct{}, 1)
+		if err := c.AddFunc("collect", func() { ran <- struct{}{} }, "0 0 * * *"); err != nil {
+			t.Fatalf("AddFunc returned %v", err)
+		}
+
+		c.RunJob("nonexistent")
+		c.RunJob("")
+
+		select {
+		case <-ran:
+			t.Error("an unknown name triggered a registered job")
+		default:
+		}
+	})
+
+	t.Run("runs a job whose spec was rejected", func(t *testing.T) {
+		c := newTestCronService(t)
+
+		ran := make(chan struct{})
+		if err := c.AddFunc("broken", func() { close(ran) }, "nonsense"); err == nil {
+			t.Fatal("AddFunc returned nil, want an error")
+		}
+
+		c.RunJob("broken")
+		<-ran
+	})
+}
+
+func TestInitCronService(t *testing.T) {
+	// A nil map here would panic on the first AddFunc at startup.
+	c := newTestCronService(t)
+
+	if c == nil || Cron != c {
+		t.Fatal("InitCronService did not set the global Cron")
+	}
+	if c.cronJobs == nil {
+		t.Error("cronJobs map is nil")
+	}
+	if c.cron == nil {
+		t.Error("cron scheduler is nil")
+	}
+}

--- a/tools/truncate_test.go
+++ b/tools/truncate_test.go
@@ -1,0 +1,462 @@
+package tools
+
+import (
+	"errors"
+	"math/rand"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// TruncateHtml is a hand-rolled parser fed lecture and course descriptions, which are
+// user-supplied. Every case here pins current behaviour; the ones marked BUG document
+// output that is wrong but shipped, so a fix is a deliberate, visible change.
+func TestTruncateHtml(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		maxlen   int
+		ellipsis string
+		want     string
+		wantErr  error
+	}{
+		{
+			name:     "an empty input yields an empty result and no ellipsis",
+			in:       "",
+			maxlen:   10,
+			ellipsis: "...",
+			want:     "",
+		},
+		{
+			// A zero budget is the one short-circuit the function takes before parsing,
+			// so it is the only way to get no ellipsis at all.
+			name:     "a maxlen of zero yields an empty result and no ellipsis",
+			in:       "hello world",
+			maxlen:   0,
+			ellipsis: "...",
+			want:     "",
+		},
+		{
+			// BUG: input that fits should come back unchanged. The ellipsis is appended
+			// unconditionally, so a short description gains a "..." that promises text
+			// which does not exist.
+			name:     "input shorter than maxlen still gains an ellipsis",
+			in:       "hello",
+			maxlen:   10,
+			ellipsis: "...",
+			want:     "hello...",
+		},
+		{
+			name:     "input exactly maxlen still gains an ellipsis",
+			in:       "hello",
+			maxlen:   5,
+			ellipsis: "...",
+			want:     "hello...",
+		},
+		{
+			name:     "input longer than maxlen is cut at the visible-character budget",
+			in:       "hello world",
+			maxlen:   5,
+			ellipsis: "...",
+			want:     "hello...",
+		},
+		{
+			name:     "an empty ellipsis appends nothing",
+			in:       "hello world",
+			maxlen:   5,
+			ellipsis: "",
+			want:     "hello",
+		},
+		{
+			// A negative budget fails the loop guard on the first iteration, so nothing
+			// is scanned and exactly one rune survives. Pinned because it is surprising:
+			// a caller passing a computed negative length gets a one-character string,
+			// not an empty one.
+			name:     "a negative maxlen emits the first rune plus the ellipsis",
+			in:       "hello",
+			maxlen:   -3,
+			ellipsis: "...",
+			want:     "h...",
+		},
+		{
+			name:     "markup does not consume the visible budget",
+			in:       "<b>hello</b>",
+			maxlen:   5,
+			ellipsis: "...",
+			want:     "<b>hello...</b>",
+		},
+		{
+			// The ellipsis goes inside the reopened tags, not after them. Worth pinning
+			// either way: it decides whether the "..." inherits the tag's styling.
+			name:     "the ellipsis is placed inside the still-open tags",
+			in:       "<b>hello</b>",
+			maxlen:   3,
+			ellipsis: "...",
+			want:     "<b>hel...</b>",
+		},
+		{
+			name:     "nested open tags are closed in reverse order",
+			in:       "<div><p><b>abcdefgh</b></p></div>",
+			maxlen:   4,
+			ellipsis: "...",
+			want:     "<div><p><b>abcd...</b></p></div>",
+		},
+		{
+			name:     "tags closed before the cut are not reopened",
+			in:       "<b>a</b><i>b</i>cdef",
+			maxlen:   3,
+			ellipsis: "...",
+			want:     "<b>a</b><i>b</i>c...",
+		},
+		{
+			name:     "an unclosed tag at the end of the input is closed for us",
+			in:       "<b>unclosed",
+			maxlen:   3,
+			ellipsis: "...",
+			want:     "<b>unc...</b>",
+		},
+		{
+			// A </br> or </img> in the output is invalid HTML and confuses browsers, so
+			// void elements must never reach the close stack.
+			name:     "a br is not pushed on the close stack",
+			in:       "a<br>bcdefg",
+			maxlen:   4,
+			ellipsis: "...",
+			want:     "a<br>bcd...",
+		},
+		{
+			name:     "an img with attributes is not pushed on the close stack",
+			in:       `a<img src="x.png" alt="y">bcdefg`,
+			maxlen:   4,
+			ellipsis: "...",
+			want:     `a<img src="x.png" alt="y">bcd...`,
+		},
+		{
+			name:     "a self-closed hr is not pushed on the close stack",
+			in:       "a<hr/>bcdefg",
+			maxlen:   4,
+			ellipsis: "...",
+			want:     "a<hr/>bcd...",
+		},
+		{
+			// BUG: the void-element list is matched case-sensitively, so uppercase
+			// markup (common in pasted rich-text) produces the invalid "</BR>".
+			name:     "an uppercase BR is wrongly closed",
+			in:       "<BR>abcdef",
+			maxlen:   3,
+			ellipsis: "...",
+			want:     "<BR>abc...</BR>",
+		},
+		{
+			name:     "tag attributes do not consume the visible budget",
+			in:       `<p class="lead" data-x="1">abcdef</p>`,
+			maxlen:   3,
+			ellipsis: "...",
+			want:     `<p class="lead" data-x="1">abc...</p>`,
+		},
+		{
+			// A half-written entity ("&am") renders as literal garbage, so the cut must
+			// land on a whole entity and count it as the single character it displays.
+			name:     "a named entity counts as one visible character",
+			in:       "ab&amp;cd",
+			maxlen:   3,
+			ellipsis: "...",
+			want:     "ab&amp;...",
+		},
+		{
+			name:     "an entity is never cut in half at the budget boundary",
+			in:       "a&amp;bcdefg",
+			maxlen:   2,
+			ellipsis: "...",
+			want:     "a&amp;...",
+		},
+		{
+			name:     "a numeric entity counts as one visible character",
+			in:       "&#8212;abcdef",
+			maxlen:   2,
+			ellipsis: "...",
+			want:     "&#8212;a...",
+		},
+		{
+			name:     "consecutive entities each count once",
+			in:       "&amp;&amp;&amp;",
+			maxlen:   2,
+			ellipsis: "...",
+			want:     "&amp;&amp;...",
+		},
+		{
+			// A bare ampersand is not an entity; it must still count as one character
+			// rather than swallowing the text behind it.
+			name:     "a bare ampersand counts as one visible character",
+			in:       "a&nope b c d",
+			maxlen:   3,
+			ellipsis: "...",
+			want:     "a&n...",
+		},
+		{
+			// German lecture titles are the common case here; a cut inside a rune
+			// produces a replacement character in the browser.
+			name:     "umlauts are counted and cut per rune",
+			in:       "äöüßabcdef",
+			maxlen:   3,
+			ellipsis: "...",
+			want:     "äöü...",
+		},
+		{
+			name:     "a four-byte emoji is never split",
+			in:       "😀😀😀abc",
+			maxlen:   2,
+			ellipsis: "...",
+			want:     "😀😀...",
+		},
+		{
+			name:     "CJK characters count one each",
+			in:       "中文字符测试",
+			maxlen:   3,
+			ellipsis: "...",
+			want:     "中文字...",
+		},
+		{
+			name:     "a multi-byte rune inside a tag is cut and the tag reclosed",
+			in:       "<b>ä</b>öü",
+			maxlen:   1,
+			ellipsis: "...",
+			want:     "<b>ä...</b>",
+		},
+		{
+			// Whitespace is deliberately excluded from the budget, so a spaced-out
+			// string yields more characters than maxlen suggests. Pinned because it is
+			// the single most surprising property of the function.
+			name:     "whitespace does not consume the visible budget",
+			in:       "a b c d e f",
+			maxlen:   3,
+			ellipsis: "...",
+			want:     "a b c...",
+		},
+		{
+			name:     "leading whitespace is preserved and uncounted",
+			in:       "   abcdef",
+			maxlen:   2,
+			ellipsis: "...",
+			want:     "   ab...",
+		},
+		{
+			name:     "a closing tag with no opener is rejected",
+			in:       "abc</b>defgh",
+			maxlen:   4,
+			ellipsis: "...",
+			wantErr:  ErrUnbalancedTags,
+		},
+		{
+			name:     "a closing tag that does not match the top of the stack is rejected",
+			in:       "<b>abc</i>defgh",
+			maxlen:   4,
+			ellipsis: "...",
+			wantErr:  ErrUnbalancedTags,
+		},
+		{
+			name:     "input that is only a closing tag is rejected",
+			in:       "</b>",
+			maxlen:   3,
+			ellipsis: "...",
+			wantErr:  ErrUnbalancedTags,
+		},
+		{
+			// A trailing "<" never reaches the tag parser because the scan stops at the
+			// end of the buffer first; contrast with TestTruncateHtmlStrayLessThanPanics.
+			name:     "a trailing stray less-than is copied through",
+			in:       "<",
+			maxlen:   3,
+			ellipsis: "...",
+			want:     "<...",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := TruncateHtml([]byte(tt.in), tt.maxlen, tt.ellipsis)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("TruncateHtml(%q, %d) error = %v, want %v", tt.in, tt.maxlen, err, tt.wantErr)
+			}
+			if tt.wantErr != nil {
+				if got != nil {
+					t.Errorf("TruncateHtml(%q, %d) = %q, want nil output alongside the error", tt.in, tt.maxlen, got)
+				}
+				return
+			}
+			if string(got) != tt.want {
+				t.Errorf("TruncateHtml(%q, %d) = %q, want %q", tt.in, tt.maxlen, got, tt.want)
+			}
+			if !utf8.Valid(got) {
+				t.Errorf("TruncateHtml(%q, %d) produced invalid UTF-8: %q", tt.in, tt.maxlen, got)
+			}
+		})
+	}
+}
+
+// BUG: a "<" that does not start a tag makes TagExpr.FindSubmatch return nil, which is
+// then indexed unguarded. "5 < 10" or an HTML comment in a course description crashes
+// the request. Pinned as a panic so a fix turns this test red rather than passing
+// silently.
+func TestTruncateHtmlStrayLessThanPanics(t *testing.T) {
+	inputs := []string{
+		"a < b and more text",
+		"5 < 10 and 3 > 1 blah",
+		"<!-- a comment -->abcdef",
+	}
+	for _, in := range inputs {
+		t.Run(in, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("TruncateHtml(%q) no longer panics; the nil-match crash appears fixed, update this test", in)
+				}
+			}()
+			_, _ = TruncateHtml([]byte(in), 5, "...")
+		})
+	}
+}
+
+// BUG: the end-of-buffer check compares bufPtr against len(buf)-1, which only holds
+// when the final rune is one byte wide. An input whose last rune is multi-byte and
+// whose budget is not exhausted before it falls through to the tag parser with no tag
+// left to match, and crashes. Only the final rune decides, so "Grüße" is safe and "bä"
+// is not -- which is how this survived unnoticed in a German university's codebase.
+func TestTruncateHtmlPanicsOnTrailingMultiByteRune(t *testing.T) {
+	inputs := []string{"ä", "bä", "ö", "😀", "中", "Vorlesung über Prüfungsordnungä"}
+	for _, in := range inputs {
+		t.Run(in, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("TruncateHtml(%q) no longer panics; the end-of-buffer check appears fixed, update this test", in)
+				}
+			}()
+			_, _ = TruncateHtml([]byte(in), 100, "...")
+		})
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     string
+		length int
+		want   string
+	}{
+		{
+			name:   "an empty input yields an empty string",
+			in:     "",
+			length: 5,
+			want:   "",
+		},
+		{
+			name:   "a zero length yields an empty string",
+			in:     "hello",
+			length: 0,
+			want:   "",
+		},
+		{
+			// Same unconditional-ellipsis bug as TruncateHtml, surfaced through the
+			// wrapper that templates actually call.
+			name:   "input shorter than the length still gains an ellipsis",
+			in:     "hello",
+			length: 10,
+			want:   "hello...",
+		},
+		{
+			name:   "input exactly the length still gains an ellipsis",
+			in:     "hello",
+			length: 5,
+			want:   "hello...",
+		},
+		{
+			name:   "input longer than the length is truncated",
+			in:     "hello world",
+			length: 5,
+			want:   "hello...",
+		},
+		{
+			// Counting is per rune, not per byte: "äö" is four bytes but two characters,
+			// and neither is split.
+			name:   "multi-byte input is cut by rune, not by byte",
+			in:     "äöü",
+			length: 2,
+			want:   "äö...",
+		},
+		{
+			name:   "emoji are cut by rune",
+			in:     "😀😀😀",
+			length: 2,
+			want:   "😀😀...",
+		},
+		{
+			// BUG: the error branch assigns to a blank identifier and falls through, so
+			// unbalanced markup silently discards the whole text instead of degrading to
+			// something readable.
+			name:   "unbalanced markup silently yields an empty string",
+			in:     "a</b>",
+			length: 3,
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Truncate(tt.in, tt.length); got != tt.want {
+				t.Errorf("Truncate(%q, %d) = %q, want %q", tt.in, tt.length, got, tt.want)
+			}
+		})
+	}
+}
+
+// Randomised smoke test over markup-shaped input. It does not recompute the visible
+// count (that would just reimplement the function); it pins the three properties that
+// must hold for any input: no crash, valid UTF-8 out, and output that is the input
+// prefix plus the ellipsis and closing tags — never unrelated bytes.
+func TestTruncateHtmlPropertiesOnGeneratedInput(t *testing.T) {
+	tokens := []string{
+		"a", "b", " ", "  ", "ä", "ö", "ß", "😀", "中", "&amp;", "&#8212;", "&",
+		"<b>", "</b>", "<i>", "</i>", "<br>", "<hr/>", `<img src="x">`, "\n", "\t",
+	}
+	const ellipsis = "…"
+
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < 2000; i++ {
+		var sb strings.Builder
+		for n := rng.Intn(12); n >= 0; n-- {
+			sb.WriteString(tokens[rng.Intn(len(tokens))])
+		}
+		// Every input is terminated with an ASCII byte: an input ending in a multi-byte
+		// rune crashes (see TestTruncateHtmlPanicsOnTrailingMultiByteRune), which would
+		// otherwise mask every other property this loop checks.
+		sb.WriteString("z")
+		in := sb.String()
+		maxlen := rng.Intn(12)
+
+		got, err := TruncateHtml([]byte(in), maxlen, ellipsis)
+		if err != nil {
+			if !errors.Is(err, ErrUnbalancedTags) {
+				t.Fatalf("TruncateHtml(%q, %d) returned unexpected error %v", in, maxlen, err)
+			}
+			continue
+		}
+		if !utf8.Valid(got) {
+			t.Fatalf("TruncateHtml(%q, %d) produced invalid UTF-8: %q", in, maxlen, got)
+		}
+		out := string(got)
+		if out == "" {
+			continue
+		}
+		cut := strings.Index(out, ellipsis)
+		if cut < 0 {
+			t.Fatalf("TruncateHtml(%q, %d) = %q, dropped the ellipsis", in, maxlen, out)
+		}
+		if !strings.HasPrefix(in, out[:cut]) {
+			t.Fatalf("TruncateHtml(%q, %d) = %q, kept text that is not a prefix of the input", in, maxlen, out)
+		}
+		for _, rest := range strings.Split(strings.TrimSuffix(strings.TrimPrefix(out[cut:], ellipsis), ">"), ">") {
+			if rest != "" && !strings.HasPrefix(rest, "</") {
+				t.Fatalf("TruncateHtml(%q, %d) = %q, appended something other than closing tags", in, maxlen, out)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds ~4,000 lines of unit tests across the three areas that carried the most untested logic: `model/user.go` (507 lines, no tests), `model/stream.go` (434, no tests), the pure helpers in `tools/`, and all of `pkg/camera/`.

No production code is touched.

| Area | What is covered |
|---|---|
| `model/user_test.go` | Course eligibility across all four visibilities × every role (incl. the anonymous caller), Argon2 round trips and malformed-hash decoding, settings JSON decoding and its defaults, semester filtering boundaries |
| `model/stream_test.go` | Time-state predicates and their boundaries, VOD and thumbnail resolution, the description sanitiser as an XSS boundary, `GetJson` |
| `tools/` | `TruncateHtml` against entities, multi-byte runes and unbalanced tags; canonical URL building; the error middleware; the cron service; branding |
| `pkg/camera/` | The three PTZ drivers against `httptest` servers — CGI request construction plus the offline, unauthorized and malformed-response paths — the shared protocol helper, and the mockgen contract |

`dao/` is deliberately left out: it needs a database, so it is an integration gap rather than a unit-test one.

## Bugs found

Writing these surfaced several genuine defects. **The tests pin current behaviour, including where that behaviour is wrong**, each marked with a `BUG` comment so the assertion is not read as an endorsement. Fixes follow as separate PRs so they can be reviewed and merged selectively.

Crashes on untrusted input:

- **`TruncateHtml` panics** (`tools/truncate.go:108`) on any input ending in a multi-byte rune, on a bare `<`, and on HTML comments. The guard `bufPtr >= len(buf)-1` compares a byte offset against the last *byte*, so a wider final rune falls through to an unchecked `FindSubmatch` result. `"bä"` panics; `"Grüße"` does not, because it ends in ASCII. A lecture description ending in an umlaut or an emoji crashes the request.
- **`protocol.MakeAuthenticatedRequest` panics** on a credential without a colon, reachable from configuration alone — `camera.Service.For` sets `auth = ""` for a camera type missing from the auths map, so a hall with no configured credentials crashes on the first PTZ request.

Wrong in production today:

- **`CanonicalURL` emits `https:/…`** — `path.Join` runs `path.Clean`, which collapses the scheme's `//`. This is rendered into `<link rel="canonical">` on watch and info pages. `path.Clean` also resolves `..` inside user-influenced course slugs.
- **Camera non-200 responses are treated as success** — `SetPreset` discards the status, so an unauthorized or erroring camera reports a successful preset change, and `TakeSnapshot` writes the 401 error page to disk as a `.jpg`.
- **`decodeHash` mutates the package-global Argon2 parameters** (`model/user.go:431-446`) — verifying one stored hash overwrites the cost used for every subsequent password, so a single weak legacy hash downgrades the whole process. It is also an unsynchronised global write on every concurrent login.

Quieter, but pinned:

- `Truncate` swallows `ErrUnbalancedTags` via a no-op `_ = []byte("")` and returns `""`, so one stray closing tag erases an entire description.
- The ellipsis is appended even when nothing was truncated (`Truncate("hello", 10) == "hello..."`).
- `IsStartingInOneDay` implements the inverse of its doc comment. Currently dead code, so nothing is broken yet.
- `FirstSilenceAsProgress` yields `+Inf`/`NaN` on a zero-length stream, which will not marshal to JSON.
- `ErrorHandler`'s two branches return incompatible body shapes, and the plain-error branch leaks raw internal error text to the client.
- Void elements are matched case-sensitively, so `<BR>` produces a `</BR>` in the output.

## Testing

`go test -race -count=2 ./model/... ./tools/... ./pkg/...` passes, as do `go vet` and `gofmt`. The camera tests use `httptest` throughout — no real network, no fixed ports, no sleeps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
