### PR TITLE
fix(model): stop decodeHash from mutating the global argon2 parameters

### DIFF
--- a/model/user.go
+++ b/model/user.go
@@ -395,14 +395,15 @@ func (u *User) ComparePasswordAndHash(password string) (match bool, err error) {
 		return false, nil
 	}
 	// Extract the parameters, salt and derived key from the encoded password
-	// hash.
-	salt, hash, err := decodeHash(u.Password)
+	// hash. The parameters are the ones this hash was created with, which may
+	// differ from the current generation policy in `p`.
+	hashParams, salt, hash, err := decodeHash(u.Password)
 	if err != nil {
 		return false, err
 	}
 
 	// Derive the key from the other password using the same parameters.
-	otherHash := argon2.IDKey([]byte(password), salt, p.iterations, p.memory, p.parallelism, p.keyLength)
+	otherHash := argon2.IDKey([]byte(password), salt, hashParams.iterations, hashParams.memory, hashParams.parallelism, hashParams.keyLength)
 
 	// Check that the contents of the hashed passwords are identical. Note
 	// that we are using the subtle.ConstantTimeCompare() function for this
@@ -413,39 +414,42 @@ func (u *User) ComparePasswordAndHash(password string) (match bool, err error) {
 	return false, nil
 }
 
-func decodeHash(encodedHash string) (salt, hash []byte, err error) {
+// decodeHash extracts the parameters, salt and derived key of an encoded hash. The
+// parameters are returned rather than written to the package level `p`: they belong to
+// the hash being verified, while `p` is the policy for generating new hashes.
+func decodeHash(encodedHash string) (params argonParams, salt, hash []byte, err error) {
 	vals := strings.Split(encodedHash, "$")
 	if len(vals) != 6 {
-		return nil, nil, ErrInvalidHash
+		return argonParams{}, nil, nil, ErrInvalidHash
 	}
 
 	var version int
 	_, err = fmt.Sscanf(vals[2], "v=%d", &version)
 	if err != nil {
-		return nil, nil, err
+		return argonParams{}, nil, nil, err
 	}
 	if version != argon2.Version {
-		return nil, nil, ErrIncompatibleVersion
+		return argonParams{}, nil, nil, ErrIncompatibleVersion
 	}
 
-	_, err = fmt.Sscanf(vals[3], "m=%d,t=%d,p=%d", &p.memory, &p.iterations, &p.parallelism)
+	_, err = fmt.Sscanf(vals[3], "m=%d,t=%d,p=%d", &params.memory, &params.iterations, &params.parallelism)
 	if err != nil {
-		return nil, nil, err
+		return argonParams{}, nil, nil, err
 	}
 
 	salt, err = base64.RawStdEncoding.DecodeString(vals[4])
 	if err != nil {
-		return nil, nil, err
+		return argonParams{}, nil, nil, err
 	}
-	p.saltLength = uint32(len(salt))
+	params.saltLength = uint32(len(salt))
 
 	hash, err = base64.RawStdEncoding.DecodeString(vals[5])
 	if err != nil {
-		return nil, nil, err
+		return argonParams{}, nil, nil, err
 	}
-	p.keyLength = uint32(len(hash))
+	params.keyLength = uint32(len(hash))
 
-	return salt, hash, nil
+	return params, salt, hash, nil
 }
 
 func GenerateFromPassword(password string) (encodedHash string, err error) {

--- a/model/user_test.go
+++ b/model/user_test.go
@@ -1,9 +1,13 @@
 package model
 
 import (
+	"crypto/rand"
 	"database/sql"
+	"encoding/base64"
 	"errors"
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -153,8 +157,6 @@ func TestAccessChecksDoNotPanicOnNilUser(t *testing.T) {
 // A password round trip is the login path; the wrong-password and empty-hash cases are
 // what keep a broken comparison from admitting everyone.
 func TestSetPasswordAndCompare(t *testing.T) {
-	restoreArgonParams(t)
-
 	t.Run("a correct password matches", func(t *testing.T) {
 		u := &User{}
 		if err := u.SetPassword("hunter2hunter2"); err != nil {
@@ -222,8 +224,6 @@ func TestSetPasswordAndCompare(t *testing.T) {
 // If the salt were ever fixed, two users with the same password would share a hash and
 // the whole table would be crackable at once.
 func TestGenerateFromPasswordSaltsEachHash(t *testing.T) {
-	restoreArgonParams(t)
-
 	first, err := GenerateFromPassword("hunter2hunter2")
 	if err != nil {
 		t.Fatalf("GenerateFromPassword: %v", err)
@@ -249,8 +249,6 @@ func TestGenerateFromPasswordSaltsEachHash(t *testing.T) {
 // decodeHash parses attacker-adjacent data (whatever sits in the password column), so
 // every malformed shape must come back as an error instead of a panic or a false match.
 func TestDecodeHashRejectsMalformedInput(t *testing.T) {
-	restoreArgonParams(t)
-
 	valid, err := GenerateFromPassword("hunter2hunter2")
 	if err != nil {
 		t.Fatalf("GenerateFromPassword: %v", err)
@@ -274,7 +272,7 @@ func TestDecodeHashRejectsMalformedInput(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			salt, hash, err := decodeHash(tt.encoded)
+			_, salt, hash, err := decodeHash(tt.encoded)
 			if err == nil {
 				t.Fatalf("decodeHash(%q) accepted the input", tt.encoded)
 			}
@@ -288,7 +286,7 @@ func TestDecodeHashRejectsMalformedInput(t *testing.T) {
 	}
 
 	t.Run("a hash generated here round trips", func(t *testing.T) {
-		salt, hash, err := decodeHash(valid)
+		_, salt, hash, err := decodeHash(valid)
 		if err != nil {
 			t.Fatalf("decodeHash: %v", err)
 		}
@@ -298,29 +296,113 @@ func TestDecodeHashRejectsMalformedInput(t *testing.T) {
 	})
 }
 
-// BUG (asserted as-is, not fixed): decodeHash writes the parameters it parsed into the
-// package level `p`, so verifying one user's hash changes the cost parameters used to
-// generate everyone else's from then on — and races when two logins decode at once.
-// This pins the current behaviour so a fix is a deliberate, visible change.
-func TestDecodeHashMutatesGlobalParameters(t *testing.T) {
-	restoreArgonParams(t)
+// decodeHash used to write the parameters it parsed into the package level `p`, which
+// both downgraded the cost of every password hashed afterwards by the process and raced
+// between concurrent logins. The parsed parameters are per-hash state now.
+func TestDecodeHashLeavesGlobalParametersUntouched(t *testing.T) {
+	before := p
 
 	// Same argon2 version, but half the memory of the configured parameters.
 	weak := "$argon2id$v=19$m=32768,t=1,p=1$c2FsdHNhbHRzYWx0$aGFzaGhhc2hoYXNo"
-	if _, _, err := decodeHash(weak); err != nil {
+	params, _, _, err := decodeHash(weak)
+	if err != nil {
 		t.Fatalf("decodeHash: %v", err)
 	}
-	if p.memory != 32768 || p.iterations != 1 || p.parallelism != 1 {
-		t.Errorf("global params = %+v; the mutation this test documents seems to be gone", p)
+	if p != before {
+		t.Errorf("global params = %+v, want %+v; decodeHash mutated the generation policy", p, before)
+	}
+	if params.memory != 32768 || params.iterations != 1 || params.parallelism != 1 {
+		t.Errorf("decoded params = %+v; the hash's own parameters were not returned", params)
 	}
 }
 
-// restoreArgonParams puts the package level argon2 parameters back after a test, since
-// decodeHash overwrites them (see TestDecodeHashMutatesGlobalParameters).
-func restoreArgonParams(t *testing.T) {
+// Stored hashes predate any change to the generation policy, so verification has to use
+// each hash's own parameters. A fix that reached for the global `p` instead would lock
+// out every user whose hash was made with different ones.
+func TestComparePasswordAndHashUsesTheStoredParameters(t *testing.T) {
+	const password = "hunter2hunter2"
+
+	// Deliberately weaker than the current policy, as a legacy hash would be.
+	legacy := argonParams{memory: 32 * 1024, iterations: 1, parallelism: 1, saltLength: 16, keyLength: 32}
+	u := &User{Password: encodeWithParams(t, password, legacy)}
+
+	match, err := u.ComparePasswordAndHash(password)
+	if err != nil {
+		t.Fatalf("ComparePasswordAndHash: %v", err)
+	}
+	if !match {
+		t.Error("a hash stored with older parameters no longer verifies")
+	}
+
+	match, err = u.ComparePasswordAndHash("hunter2hunter3")
+	if err != nil {
+		t.Fatalf("ComparePasswordAndHash: %v", err)
+	}
+	if match {
+		t.Error("a wrong password matched a hash with older parameters")
+	}
+
+	// Hashing a new password afterwards must still use the configured policy.
+	fresh, err := GenerateFromPassword(password)
+	if err != nil {
+		t.Fatalf("GenerateFromPassword: %v", err)
+	}
+	freshParams, _, _, err := decodeHash(fresh)
+	if err != nil {
+		t.Fatalf("decodeHash: %v", err)
+	}
+	if freshParams.memory != p.memory || freshParams.iterations != p.iterations || freshParams.parallelism != p.parallelism {
+		t.Errorf("new hash encoded %+v, want the configured policy %+v", freshParams, p)
+	}
+}
+
+// Concurrent logins all decode at once; under -race this pins the unsynchronised write
+// to the global that decodeHash used to perform.
+func TestComparePasswordAndHashIsConcurrencySafe(t *testing.T) {
+	const password = "hunter2hunter2"
+	before := p
+
+	users := []*User{
+		{Password: encodeWithParams(t, password, argonParams{memory: 32 * 1024, iterations: 1, parallelism: 1, saltLength: 16, keyLength: 32})},
+		{Password: encodeWithParams(t, password, argonParams{memory: 16 * 1024, iterations: 2, parallelism: 4, saltLength: 8, keyLength: 16})},
+		{Password: encodeWithParams(t, password, p)},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		for _, u := range users {
+			wg.Add(1)
+			go func(u *User) {
+				defer wg.Done()
+				match, err := u.ComparePasswordAndHash(password)
+				if err != nil {
+					t.Errorf("ComparePasswordAndHash: %v", err)
+					return
+				}
+				if !match {
+					t.Error("a concurrent verification of a correct password failed")
+				}
+			}(u)
+		}
+	}
+	wg.Wait()
+
+	if p != before {
+		t.Errorf("global params = %+v, want %+v; concurrent verification mutated them", p, before)
+	}
+}
+
+// encodeWithParams builds a stored hash with explicit parameters, standing in for rows
+// written before the current policy.
+func encodeWithParams(t *testing.T, password string, params argonParams) string {
 	t.Helper()
-	saved := p
-	t.Cleanup(func() { p = saved })
+	salt := make([]byte, params.saltLength)
+	if _, err := rand.Read(salt); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+	hash := argon2.IDKey([]byte(password), salt, params.iterations, params.memory, params.parallelism, params.keyLength)
+	return fmt.Sprintf("$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s", argon2.Version, params.memory, params.iterations, params.parallelism,
+		base64.RawStdEncoding.EncodeToString(salt), base64.RawStdEncoding.EncodeToString(hash))
 }
 
 // The settings table stores raw strings for some keys and JSON for others; a missing or


### PR DESCRIPTION
## Root cause

`decodeHash` in `model/user.go` parsed the cost parameters out of the stored hash it was
given and wrote them into the **package-level** `p`:

```go
_, err = fmt.Sscanf(vals[3], "m=%d,t=%d,p=%d", &p.memory, &p.iterations, &p.parallelism)
...
p.saltLength = uint32(len(salt))
p.keyLength  = uint32(len(hash))
```

`p` is also the policy `GenerateFromPassword` reads when hashing a **new** password, so
per-hash verification state was being written into global generation policy.

## Consequences

1. **Cost downgrade.** Verifying one user's login permanently changed the argon2
   parameters used for every password hashed afterwards by that process. A single legacy
   or deliberately weak hash in the `users.password` column downgraded new password
   hashes process-wide, and it persisted until restart.
2. **Data race.** An unsynchronised write to a global from every concurrent login.
   `go test -race` flags it once two logins decode at the same time.

## Fix

`decodeHash` now returns the parameters it parsed alongside the salt and derived key, and
`ComparePasswordAndHash` passes those to `argon2.IDKey`. The global `p` is never written
and stays purely the generation policy. Minimal, in the file's existing style.

## Existing stored hashes still verify

This is the regression a careless fix introduces: comparing a stored hash **requires** that
hash's own parameters, not the current policy — using `p` instead would lock out every user
whose hash was made with different ones. That is exactly why the values are parsed, and the
fix keeps it.

`TestComparePasswordAndHashUsesTheStoredParameters` proves it: it builds a hash with
deliberately weaker-than-policy parameters (m=32768, t=1, p=1), asserts it still verifies,
asserts a wrong password still fails against it, and asserts that a password hashed
afterwards is encoded with the configured policy rather than the legacy one. Reverting the
fix to use the global `p` for the comparison makes this test fail.

## Constant-time comparison

Checked: yes, already constant-time. `ComparePasswordAndHash` uses
`subtle.ConstantTimeCompare(hash, otherHash) == 1` for the final comparison; unchanged by
this PR.

## Tests

- `TestDecodeHashMutatesGlobalParameters` (which pinned the bug) is rewritten as
  `TestDecodeHashLeavesGlobalParametersUntouched`: decoding a weak hash must leave `p`
  identical and must return the hash's own parameters to the caller.
- `TestComparePasswordAndHashUsesTheStoredParameters` — the regression guard described above.
- `TestComparePasswordAndHashIsConcurrencySafe` — verifies three hashes with differing
  parameters from 24 goroutines, asserting every verification succeeds and `p` is unchanged.
  Under `-race` this pins the race itself.
- The `restoreArgonParams` helper existed only because `decodeHash` overwrote the global; it
  is now unused and removed, along with its call sites.

Verified clean: `go test -race -count=2 ./model/...`, `go vet ./model/...`, `gofmt -l model/`.

## Base branch

This was written against #1955 (`test/cover-model-tools-camera`), which added the test that
pinned this behaviour. #1955 has since merged, so it targets `dev` directly — no retarget
needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
