### PR TITLE
fix(tools): unify ErrorHandler responses and stop leaking internal errors

### DIFF
--- a/tools/api-errors.go
+++ b/tools/api-errors.go
@@ -29,19 +29,37 @@ func (r RequestError) ToResponse() gin.H {
 	return res
 }
 
+// GenericInternalErrorMessage is what a client is told when a handler pushes a plain
+// error instead of a RequestError. Raw Go error strings routinely carry SQL fragments,
+// file paths and internal hostnames, so the real cause is logged rather than returned.
+const GenericInternalErrorMessage = "internal server error"
+
 func ErrorHandler(c *gin.Context) {
 	c.Next()
-	if len(c.Errors) > 0 {
-		err := c.Errors[0]
-		switch tErr := err.Err.(type) {
-		case RequestError:
-			c.Errors = []*gin.Error{} // clear errors so they don't get logged
-			c.JSON(tErr.Status, tErr.ToResponse())
-		default:
-			c.Errors = []*gin.Error{} // clear errors so they don't get logged
-			c.JSON(http.StatusInternalServerError, err.Err.Error())
-		}
-		c.Abort()
+	if len(c.Errors) == 0 {
 		return
 	}
+
+	err := c.Errors[0]
+	c.Errors = []*gin.Error{} // clear errors so they don't get logged twice
+
+	switch tErr := err.Err.(type) {
+	case RequestError:
+		// Deliberately constructed by a handler, so its message and cause are meant
+		// for the client.
+		c.JSON(tErr.Status, tErr.ToResponse())
+	default:
+		// Unexpected error: keep it server-side and hand the client the same shape
+		// with a generic message.
+		logger.Error("unhandled error while serving request",
+			"err", err.Err,
+			"method", c.Request.Method,
+			"path", c.Request.URL.Path,
+		)
+		c.JSON(http.StatusInternalServerError, RequestError{
+			Status:        http.StatusInternalServerError,
+			CustomMessage: GenericInternalErrorMessage,
+		}.ToResponse())
+	}
+	c.Abort()
 }

--- a/tools/api-errors_test.go
+++ b/tools/api-errors_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -89,10 +90,7 @@ func TestErrorHandler(t *testing.T) {
 		if rec.Code != http.StatusNotFound {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
 		}
-		var body map[string]any
-		if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
-			t.Fatalf("body %q is not JSON: %v", rec.Body.String(), err)
-		}
+		body := decodeJSONObject(t, rec)
 		want := map[string]any{"status": float64(http.StatusNotFound), "message": "no such stream", "error": "record not found"}
 		for k, v := range want {
 			if body[k] != v {
@@ -101,18 +99,55 @@ func TestErrorHandler(t *testing.T) {
 		}
 	})
 
-	t.Run("turns a plain error into a 500 with the bare message", func(t *testing.T) {
+	t.Run("renders a RequestError without a cause and omits the error key", func(t *testing.T) {
 		rec := serveThroughErrorHandler(t, func(c *gin.Context) {
-			_ = c.Error(errors.New("database exploded"))
+			_ = c.Error(RequestError{Status: http.StatusForbidden, CustomMessage: "not your stream"})
+		})
+
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusForbidden)
+		}
+		body := decodeJSONObject(t, rec)
+		if body["status"] != float64(http.StatusForbidden) || body["message"] != "not your stream" {
+			t.Errorf("body = %v, want status/message for a forbidden request", body)
+		}
+		if _, ok := body["error"]; ok {
+			t.Errorf("body carries an %q key with no cause: %v", "error", body)
+		}
+	})
+
+	t.Run("turns a plain error into a 500 with the same object shape", func(t *testing.T) {
+		rec := serveThroughErrorHandler(t, func(c *gin.Context) {
+			_ = c.Error(errors.New("database exploded: dial tcp db.internal:3306"))
 		})
 
 		if rec.Code != http.StatusInternalServerError {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
 		}
-		// The default branch serialises the raw message as a bare JSON string, not an
-		// object, so clients cannot parse both shapes the same way.
-		if got := rec.Body.String(); got != `"database exploded"` {
-			t.Errorf("body = %q, want %q", got, `"database exploded"`)
+		// Both branches must serialise the same object so a client can parse one shape.
+		body := decodeJSONObject(t, rec)
+		if body["status"] != float64(http.StatusInternalServerError) {
+			t.Errorf("body[%q] = %v, want %d", "status", body["status"], http.StatusInternalServerError)
+		}
+		if body["message"] != GenericInternalErrorMessage {
+			t.Errorf("body[%q] = %v, want %q", "message", body["message"], GenericInternalErrorMessage)
+		}
+		if _, ok := body["error"]; ok {
+			t.Errorf("an unexpected error must not expose a cause to the client: %v", body)
+		}
+	})
+
+	// Go error strings routinely carry SQL fragments, file paths and internal
+	// hostnames; none of that may reach the client.
+	t.Run("does not leak the internal error text", func(t *testing.T) {
+		rec := serveThroughErrorHandler(t, func(c *gin.Context) {
+			_ = c.Error(errors.New("database exploded: dial tcp db.internal:3306"))
+		})
+
+		for _, secret := range []string{"database exploded", "db.internal", "3306"} {
+			if strings.Contains(rec.Body.String(), secret) {
+				t.Errorf("body %q leaks %q", rec.Body.String(), secret)
+			}
 		}
 	})
 
@@ -165,4 +200,16 @@ func serveThroughErrorHandler(t *testing.T, handler gin.HandlerFunc) *httptest.R
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/thing", nil))
 	return rec
+}
+
+// decodeJSONObject fails the test unless the recorded body is a JSON object - both
+// ErrorHandler branches must emit the same shape.
+func decodeJSONObject(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("body %q is not a JSON object: %v", rec.Body.String(), err)
+	}
+	return body
 }


### PR DESCRIPTION
`tools.ErrorHandler` is mounted in front of the API routes, but its two branches emitted incompatible response bodies, and one of them handed raw internal error text to the client.

## Before / after

**`RequestError` branch — unchanged.**

```json
{"status": 404, "message": "no such stream", "error": "record not found"}
```

**Plain-error branch — before:** a bare JSON *string* with a 500. The body was literally

```json
"database exploded: dial tcp db.internal:3306"
```

**Plain-error branch — after:** the same object shape as the other branch, with a generic message and no `error` key:

```json
{"status": 500, "message": "internal server error"}
```

I brought the plain-error branch into line with `RequestError.ToResponse()` rather than the other way round — changing the well-behaved shape is what would actually break clients.

## Information leak

The old default branch called `err.Err.Error()` and serialised it to the client. Go error strings in this codebase come out of gorm, `net`, `os` and friends, so they routinely carry SQL fragments, filesystem paths and internal hostnames. That is now logged server-side instead, via the package's existing `log/slog` logger (`tools/tools_logger.go`, the same `logger.Error("...", "err", err)` style used across `tools/`), enriched with the request method and path so the cause is not lost:

```
logger.Error("unhandled error while serving request", "err", err.Err, "method", ..., "path", ...)
```

**Why `RequestError` keeps its `error` field:** a `RequestError` is deliberately constructed by a handler that chose both the status and the `CustomMessage`, so its wrapped cause is an intentional, curated detail (`"strconv: bad syntax"`, `"record not found"`). The default branch is the opposite case — an error that escaped a handler unclassified, whose text nobody vetted for disclosure. Those two are treated differently on purpose.

## Consumers I found

Grepped `web/ts/` (there is no `frontend/src/` in this repo) and the Go tests.

- **`web/ts/admin.ts:140` `toLectureHallResult()`** is the one real parser of these bodies. It already handles **both** shapes:
  ```ts
  if (typeof body === "string") { error = body; }
  else if (body?.message) { error = body.error ? `${body.message}: ${body.error}` : body.message; }
  ```
  After this change the `typeof body === "string"` branch simply stops being reached; the object branch takes over and the lecture-hall form still shows a server-supplied message. **No frontend change is required and nothing breaks.** The visible difference is that an unexpected 500 now says `internal server error` instead of the raw database text — which is the intended behaviour.
- No other `web/ts/` code parses `.message`/`.error` off an API error body; the rest only `console.error(err)` the fetch rejection.
- No Go test in `api/` or `apiv2/` asserted on the bare-string body. `./api/...` and `./apiv2/...` pass unchanged.

## Breaking change?

Only for a client that depended on the 500 branch's bare string *and* on reading the internal message — i.e. nothing in this repo. Anything already parsing the `RequestError` shape is unaffected, and `admin.ts` was written defensively enough to cover both. I'd call this a fix rather than a breaking change, but it is a deliberate response-body change on the 500 path and worth noting in release notes.

## Nil-`Err` safety

`RequestError.Error()` already nil-checks `r.Err`, so there is no nil-deref to fix; a test case now pins that, and a new `ErrorHandler` case drives a `RequestError` with a nil `Err` end to end and asserts the `error` key is absent rather than empty.

## Tests

`tools/api-errors_test.go` assertions were rewritten (not deleted) to the unified shape. The three driver cases are kept — `RequestError`, plain error, and no error at all (which must leave the response untouched) — plus:

- a `RequestError` with a nil wrapped `Err`;
- an explicit assertion that the plain-error body contains none of `database exploded`, `db.internal`, `3306`;
- a `decodeJSONObject` helper that fails if either branch's body is not a JSON object.

## Verification

- `go test -race -count=2 ./tools/` — ok
- `go vet ./tools/` — clean
- `gofmt -l tools/` — clean
- `go test ./api/... ./apiv2/...` — all ok
- `go build ./...` — fails only at `web/router.go:26` (`pattern node_modules: no matching files found`), the pre-existing `go:embed` requirement for a built `web/node_modules`; unrelated to this change.

---

This was written on top of #1955 (`test/cover-model-tools-camera`), which added the tests that pinned the old inconsistent shapes. #1955 has since merged into `dev` and its branch is gone, so this targets `dev` directly and carries only the fix commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
