### PR TITLE
fix(tools): build canonical URLs with url.JoinPath instead of path.Join

### DIFF
--- a/tools/canonical.go
+++ b/tools/canonical.go
@@ -1,10 +1,13 @@
 package tools
 
 import (
-	"path"
+	"net/url"
 	"strconv"
+	"strings"
 )
 
+// CanonicalURL builds the absolute links that go into <link rel="canonical"> and the
+// share links, from the canonicalURL of the deployment config.
 type CanonicalURL struct {
 	url string
 }
@@ -18,17 +21,55 @@ func (c CanonicalURL) Root() string {
 }
 
 func (c CanonicalURL) Course(year int, term string, slug string) string {
-	return path.Join(c.url, "course", strconv.Itoa(year), term, slug)
+	return c.join("course", strconv.Itoa(year), term, slug)
 }
 
 func (c CanonicalURL) Stream(slug string, id uint, version string) string {
-	return path.Join(c.url, "w", slug, strconv.Itoa(int(id)), version)
+	return c.join("w", slug, strconv.FormatUint(uint64(id), 10), version)
 }
 
 func (c CanonicalURL) Login() string {
-	return path.Join(c.url, "login")
+	return c.join("login")
 }
 
 func (c CanonicalURL) Info(version string) string {
-	return path.Join(c.url, version)
+	return c.join(version)
+}
+
+// join appends the segments to the configured base URL. It uses url.JoinPath rather
+// than path.Join because the latter runs path.Clean, which collapses the "//" of the
+// scheme into "https:/" and resolves any ".." a segment carries. Every segment is
+// percent-escaped so that a caller-supplied value - a course slug is user-editable -
+// lands as exactly one path segment and cannot climb out of the path it is joined into.
+// Empty segments are dropped, so an absent stream version leaves no trailing slash.
+//
+// These methods are called straight from templates and cannot report an error, so a
+// base URL that does not parse degrades to a root-relative path instead.
+func (c CanonicalURL) join(segments ...string) string {
+	escaped := make([]string, 0, len(segments))
+	for _, segment := range segments {
+		if segment == "" {
+			continue
+		}
+		escaped = append(escaped, escapeSegment(segment))
+	}
+	if c.url != "" {
+		if joined, err := url.JoinPath(c.url, escaped...); err == nil {
+			return joined
+		}
+	}
+	// No usable base: a root-relative path still resolves from any page, which a bare
+	// relative path would not.
+	return "/" + strings.Join(escaped, "/")
+}
+
+// escapeSegment turns one path segment into its percent-encoded form. url.PathEscape
+// leaves "." and ".." alone and url.JoinPath still resolves those as traversal, so a
+// segment made up of nothing but dots is encoded by hand.
+func escapeSegment(segment string) string {
+	escaped := url.PathEscape(segment)
+	if strings.Trim(escaped, ".") == "" {
+		escaped = strings.ReplaceAll(escaped, ".", "%2E")
+	}
+	return escaped
 }

--- a/tools/canonical_test.go
+++ b/tools/canonical_test.go
@@ -13,12 +13,12 @@ func TestCanonicalURL(t *testing.T) {
 		want string
 	}{
 		{
-			// path.Clean collapses the "//" in the scheme. Every method below inherits
-			// this, so the canonical tags and share links ship a scheme-mangled URL.
-			name: "a bare origin loses a slash from its scheme once anything is joined",
+			// The scheme survives joining: path.Join used to collapse the "//" here and
+			// ship a "https:/..." canonical tag.
+			name: "a bare origin keeps its scheme once something is joined",
 			base: "https://live.rbg.tum.de",
 			got:  func(c CanonicalURL) string { return c.Login() },
-			want: "https:/live.rbg.tum.de/login",
+			want: "https://live.rbg.tum.de/login",
 		},
 		{
 			name: "Root hands back the configured base untouched",
@@ -36,86 +36,145 @@ func TestCanonicalURL(t *testing.T) {
 			name: "a trailing slash on the base does not double up",
 			base: "https://live.rbg.tum.de/",
 			got:  func(c CanonicalURL) string { return c.Login() },
-			want: "https:/live.rbg.tum.de/login",
+			want: "https://live.rbg.tum.de/login",
 		},
 		{
 			name: "a base with a path prefix keeps the prefix",
 			base: "https://example.org/tum",
 			got:  func(c CanonicalURL) string { return c.Login() },
-			want: "https:/example.org/tum/login",
+			want: "https://example.org/tum/login",
 		},
 		{
-			// An unset canonicalURL in the config yields a relative path rather than
-			// an absolute URL, which is not a valid canonical link.
-			name: "an empty base produces a bare relative path",
+			name: "a base with a path prefix and a trailing slash keeps the prefix once",
+			base: "https://example.org/tum/",
+			got:  func(c CanonicalURL) string { return c.Login() },
+			want: "https://example.org/tum/login",
+		},
+		{
+			// An unset canonicalURL in the config cannot produce an absolute URL; a
+			// root-relative path at least resolves from any page it is rendered on.
+			name: "an empty base produces a root-relative path",
 			base: "",
 			got:  func(c CanonicalURL) string { return c.Login() },
-			want: "login",
+			want: "/login",
+		},
+		{
+			// The methods are called from templates and cannot report an error, so an
+			// unparsable base degrades the same way an empty one does.
+			name: "an unparsable base degrades to a root-relative path",
+			base: "://not-a-url",
+			got:  func(c CanonicalURL) string { return c.Login() },
+			want: "/login",
 		},
 		{
 			name: "Course joins year, term and slug",
 			base: "https://live.rbg.tum.de",
 			got:  func(c CanonicalURL) string { return c.Course(2023, "W", "eidi") },
-			want: "https:/live.rbg.tum.de/course/2023/W/eidi",
+			want: "https://live.rbg.tum.de/course/2023/W/eidi",
 		},
 		{
 			name: "Course renders a negative year rather than rejecting it",
 			base: "https://live.rbg.tum.de",
 			got:  func(c CanonicalURL) string { return c.Course(-1, "S", "eidi") },
-			want: "https:/live.rbg.tum.de/course/-1/S/eidi",
+			want: "https://live.rbg.tum.de/course/-1/S/eidi",
 		},
 		{
-			// Slugs come from user-editable course settings, so what a separator in one
-			// does to the resulting URL is pinned deliberately.
-			name: "a slug containing a slash becomes an extra path segment",
+			// Slugs come from user-editable course settings, so a separator in one is
+			// escaped into the segment instead of opening a new one.
+			name: "a slug containing a slash stays a single path segment",
 			base: "https://live.rbg.tum.de",
 			got:  func(c CanonicalURL) string { return c.Course(2023, "W", "ei/di") },
-			want: "https:/live.rbg.tum.de/course/2023/W/ei/di",
+			want: "https://live.rbg.tum.de/course/2023/W/ei%2Fdi",
 		},
 		{
-			// path.Clean resolves the traversal instead of leaving it in the link, so a
-			// crafted slug can point the canonical tag at an unrelated path.
-			name: "a slug with .. is cleaned away and climbs out of the course path",
+			// A crafted slug must not be able to point the canonical tag somewhere else.
+			name: "a slug with .. cannot climb out of the course path",
 			base: "https://live.rbg.tum.de",
 			got:  func(c CanonicalURL) string { return c.Course(2023, "W", "../../../login") },
-			want: "https:/live.rbg.tum.de/login",
+			want: "https://live.rbg.tum.de/course/2023/W/..%2F..%2F..%2Flogin",
 		},
 		{
-			name: "enough .. segments collapse the whole URL to the current directory",
+			name: "a pile of .. segments no longer collapses the URL",
 			base: "https://live.rbg.tum.de",
 			got:  func(c CanonicalURL) string { return c.Course(2023, "W", "../../../../..") },
-			want: ".",
+			want: "https://live.rbg.tum.de/course/2023/W/..%2F..%2F..%2F..%2F..",
+		},
+		{
+			// url.PathEscape leaves a bare ".." alone, so it is encoded by hand.
+			name: "a slug that is exactly .. is encoded rather than resolved",
+			base: "https://live.rbg.tum.de",
+			got:  func(c CanonicalURL) string { return c.Course(2023, "W", "..") },
+			want: "https://live.rbg.tum.de/course/2023/W/%2E%2E",
+		},
+		{
+			name: "a slug that is a single dot is encoded too",
+			base: "https://live.rbg.tum.de",
+			got:  func(c CanonicalURL) string { return c.Course(2023, "W", ".") },
+			want: "https://live.rbg.tum.de/course/2023/W/%2E",
+		},
+		{
+			// The course slug regex allows umlauts, which are percent-encoded here -
+			// the escaped form is what a browser sends for the same link anyway.
+			name: "a slug with a non-ASCII character is percent-encoded",
+			base: "https://live.rbg.tum.de",
+			got:  func(c CanonicalURL) string { return c.Course(2023, "W", "grüße") },
+			want: "https://live.rbg.tum.de/course/2023/W/gr%C3%BC%C3%9Fe",
+		},
+		{
+			name: "a slug with a space is percent-encoded rather than splitting the URL",
+			base: "https://live.rbg.tum.de",
+			got:  func(c CanonicalURL) string { return c.Course(2023, "W", "ei di") },
+			want: "https://live.rbg.tum.de/course/2023/W/ei%20di",
+		},
+		{
+			// A query or fragment marker in a slug must not end the path either.
+			name: "a slug with ? or # stays inside the path",
+			base: "https://live.rbg.tum.de",
+			got:  func(c CanonicalURL) string { return c.Course(2023, "W", "ei?a#b") },
+			want: "https://live.rbg.tum.de/course/2023/W/ei%3Fa%23b",
 		},
 		{
 			name: "Stream joins slug, id and version",
 			base: "https://live.rbg.tum.de",
 			got:  func(c CanonicalURL) string { return c.Stream("eidi", 42, "CAM") },
-			want: "https:/live.rbg.tum.de/w/eidi/42/CAM",
+			want: "https://live.rbg.tum.de/w/eidi/42/CAM",
 		},
 		{
 			name: "Stream drops an empty version instead of leaving a trailing slash",
 			base: "https://live.rbg.tum.de",
 			got:  func(c CanonicalURL) string { return c.Stream("eidi", 42, "") },
-			want: "https:/live.rbg.tum.de/w/eidi/42",
+			want: "https://live.rbg.tum.de/w/eidi/42",
 		},
 		{
-			// The id is a uint but is narrowed through int before formatting.
 			name: "Stream formats a large id without wrapping",
 			base: "https://live.rbg.tum.de",
 			got:  func(c CanonicalURL) string { return c.Stream("eidi", 4294967295, "PRES") },
-			want: "https:/live.rbg.tum.de/w/eidi/4294967295/PRES",
+			want: "https://live.rbg.tum.de/w/eidi/4294967295/PRES",
+		},
+		{
+			name: "Stream on a base with a path prefix keeps the prefix",
+			base: "https://example.org/tum",
+			got:  func(c CanonicalURL) string { return c.Stream("eidi", 42, "COMB") },
+			want: "https://example.org/tum/w/eidi/42/COMB",
 		},
 		{
 			name: "Info appends the page name",
 			base: "https://live.rbg.tum.de",
 			got:  func(c CanonicalURL) string { return c.Info("imprint") },
-			want: "https:/live.rbg.tum.de/imprint",
+			want: "https://live.rbg.tum.de/imprint",
 		},
 		{
-			name: "Info with an empty name falls back to the cleaned origin",
+			// Nothing to append, so the link is the origin itself, in its root form.
+			name: "Info with an empty name falls back to the origin root",
 			base: "https://live.rbg.tum.de",
 			got:  func(c CanonicalURL) string { return c.Info("") },
-			want: "https:/live.rbg.tum.de",
+			want: "https://live.rbg.tum.de/",
+		},
+		{
+			name: "Info with an empty name on a base with a trailing slash keeps the origin",
+			base: "https://live.rbg.tum.de/",
+			got:  func(c CanonicalURL) string { return c.Info("") },
+			want: "https://live.rbg.tum.de/",
 		},
 	}
 


### PR DESCRIPTION
## The bug

`tools.CanonicalURL` joined its segments with `path.Join`, which runs `path.Clean`. `Clean` collapses the `//` of the scheme, so every method except `Root` produced a malformed origin:

| call | before | after |
| --- | --- | --- |
| `Login()` | `https:/live.rbg.tum.de/login` | `https://live.rbg.tum.de/login` |
| `Course(2023, "W", "eidi")` | `https:/live.rbg.tum.de/course/2023/W/eidi` | `https://live.rbg.tum.de/course/2023/W/eidi` |
| `Stream("eidi", 42, "CAM")` | `https:/live.rbg.tum.de/w/eidi/42/CAM` | `https://live.rbg.tum.de/w/eidi/42/CAM` |
| `Info("imprint")` | `https:/live.rbg.tum.de/imprint` | `https://live.rbg.tum.de/imprint` |

**This is live in production output.** The value is rendered into `<link rel="canonical">` by `web/template/watch.gohtml:10` (`.CanonicalURL.Stream $course.Slug $stream.ID .Version`) and `web/template/info-page.gohtml:6` (`.CanonicalURL.Info .Name`), fed from `tools.Cfg.CanonicalURL` via `web/index.go:66` and `web/user.go:184`. `config.yaml` ships `canonicalURL: https://tum.live`, so every watch page and every info page (`/privacy`, `/imprint`, `/about`) currently advertises a canonical URL with a one-slash scheme — search engines and anything resolving those links get a broken address.

### Related: `..` in a slug

`path.Clean` also resolved traversal inside the joined segments, and course slugs are user-editable:

- `Course(2023, "W", "../../../login")` → `https:/live.rbg.tum.de/login`
- `Course(2023, "W", "../../../../..")` → `"."`

So a crafted slug could point the canonical tag at an unrelated path, or erase the URL entirely.

## The fix

`url.JoinPath` instead of `path.Join`. It keeps the scheme intact and handles the base-URL shapes correctly: trailing slash, no trailing slash, and a path prefix (`https://example.org/tum` → `https://example.org/tum/login`, no doubled slash either way).

`url.JoinPath` still resolves `..`, so caller-supplied segments are run through `url.PathEscape` first. `PathEscape` leaves a bare `.` and `..` untouched, so a segment consisting only of dots is encoded by hand (`..` → `%2E%2E`). Result for a hostile slug:

```
Course(2023, "W", "../../../login")
  -> https://live.rbg.tum.de/course/2023/W/..%2F..%2F..%2Flogin
Course(2023, "W", "..")
  -> https://live.rbg.tum.de/course/2023/W/%2E%2E
```

The link now always stays inside `/course/<year>/<term>/`, pointing at a course that does not exist rather than at `/login`.

### Effect on legitimate slugs

`model/course.go:350` validates slugs against `^[a-zA-Z0-9äöüÄÖÜ\-_]{1,150}$`. For everything in that set except the umlauts, `PathEscape` is a no-op, so normal slugs (`eidi`, `GBS`, `TEST-<hash>`) render byte-for-byte as before. Umlauts are the one visible change: `grüße` now renders as `gr%C3%BC%C3%9Fe` rather than raw UTF-8. Note that `url.JoinPath` percent-encodes non-ASCII on its own regardless — `PathEscape` does not add this — and the escaped form is exactly what a browser sends for the same link, so the two are equivalent for canonicalisation.

### Signatures and error handling

`Root`, `Course`, `Stream`, `Login`, `Info` keep their signatures — they are called from templates, which cannot handle an error. An unparsable base degrades to a root-relative path (`/login`) instead. The previously pinned behaviour for an empty `canonicalURL` was a bare relative path (`login`), which resolves differently depending on the page it is rendered on; it is now `/login` for the same reason.

`Stream` also switched `strconv.Itoa(int(id))` to `strconv.FormatUint`, so the `uint` id is no longer narrowed through `int`.

## Call sites checked

`web/template/watch.gohtml`, `web/template/info-page.gohtml`, `web/index.go:66`, `web/user.go:184`. **Neither template nor either handler compensated for the bug** — no slash stripping, no string surgery, the value is interpolated straight into the `href`. So there is no double-correction to worry about; they simply start receiving a well-formed URL. `.Name` in `info-page.gohtml` comes from hard-coded route literals (`web/router.go:260-262`), and `apiv2/server/config.go:32` passes `tools.Cfg.CanonicalURL` through raw, untouched by this change.

## Tests

`tools/canonical_test.go` (added by #1955) pinned the broken output — the `https:/` form and the `..` traversal. Those assertions are rewritten to the correct output rather than deleted, and the matrix is kept and extended: bare origin, trailing slash, path prefix with and without trailing slash, empty base, unparsable base, plus new cases for a hostile slug, a bare `..` and `.`, a slug with a space, a non-ASCII slug, and a slug carrying `?`/`#`.

`go test -race -count=2 ./tools/`, `go vet ./tools/` and `gofmt -l tools/` are clean. `go build ./...` fails only on the pre-existing `web/router.go:26` `go:embed node_modules` pattern (no `web/node_modules` in this checkout), which is unrelated to this change.

## Target branch

This was meant to target #1955 (`test/cover-model-tools-camera`), whose tests it corrects. #1955 has since been squash-merged as c8fe4634 and its branch deleted, so this targets `dev` directly and contains only the fix commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
