### PR TITLE
fix(camera): treat a non-200 camera response as an error

### DIFF
--- a/pkg/camera/axis/axis_test.go
+++ b/pkg/camera/axis/axis_test.go
@@ -1,13 +1,17 @@
 package axis
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/TUM-Dev/gocast/pkg/camera/protocol"
 )
 
 // recorder captures what the camera would have received, so the vendor CGI string can be
@@ -42,6 +46,24 @@ func offlineCam(t *testing.T) *AxisCam {
 	return NewAxisCam(strings.TrimPrefix(srv.URL, "http://"), "user:password")
 }
 
+// assertEmptyDir fails if anything was written into dir. A snapshot that failed must
+// leave nothing behind: whatever consumes lecture-hall snapshots cannot tell a stored
+// error page from a real JPEG.
+func assertEmptyDir(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading output directory: %v", err)
+	}
+	if len(entries) != 0 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("output directory contains %v, want no file at all", names)
+	}
+}
+
 func TestSetPreset(t *testing.T) {
 	// Negative and out-of-range ids are included deliberately: the driver does no
 	// validation, it formats whatever it is given straight into the CGI query.
@@ -74,13 +96,22 @@ func TestSetPreset(t *testing.T) {
 		})
 	}
 
-	// BUG: the status code is discarded, so a camera answering 401 or 500 looks like a
-	// successful preset change to every caller.
-	t.Run("a failing camera is reported as success", func(t *testing.T) {
+	// A camera that answers 401 or 500 has not moved. Reporting that as a successful preset
+	// change left an operator watching a stream that never changed angle, with nothing in
+	// the logs; the status is now an error naming the code.
+	t.Run("a failing camera returns an error", func(t *testing.T) {
 		for _, code := range []int{http.StatusInternalServerError, http.StatusUnauthorized} {
 			cam, _ := newCam(t, func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(code) })
-			if err := cam.SetPreset(1); err != nil {
-				t.Errorf("code %d: got error %v; if status handling was added, update this test", code, err)
+			err := cam.SetPreset(1)
+			if err == nil {
+				t.Errorf("code %d: expected an error, the camera did not move", code)
+				continue
+			}
+			if !errors.Is(err, protocol.ErrUnexpectedStatus) {
+				t.Errorf("code %d: error %v does not match protocol.ErrUnexpectedStatus", code, err)
+			}
+			if !strings.Contains(err.Error(), strconv.Itoa(code)) {
+				t.Errorf("code %d: error %q does not name the status code", code, err)
 			}
 		}
 	})
@@ -135,6 +166,61 @@ func TestTakeSnapshot(t *testing.T) {
 		}
 	})
 
+	// The regression worth locking down: an error response used to be written to disk as a
+	// .jpg and handed back as a valid snapshot filename.
+	t.Run("an error response leaves no file on disk", func(t *testing.T) {
+		cases := []struct {
+			name string
+			code int
+			body string
+		}{
+			{name: "500 with an html error page", code: http.StatusInternalServerError, body: "<html><body>Internal Server Error</body></html>"},
+			{name: "401 with an html error page", code: http.StatusUnauthorized, body: "<html><head><title>401 Unauthorized</title></head></html>"},
+			{name: "401 with an empty body", code: http.StatusUnauthorized, body: ""},
+		}
+		for _, tt := range cases {
+			t.Run(tt.name, func(t *testing.T) {
+				dir := t.TempDir()
+				cam, _ := newCam(t, func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(tt.code)
+					_, _ = w.Write([]byte(tt.body))
+				})
+				filename, err := cam.TakeSnapshot(dir)
+				if err == nil {
+					t.Fatalf("expected an error, got filename %q", filename)
+				}
+				if !errors.Is(err, protocol.ErrUnexpectedStatus) {
+					t.Errorf("error %v does not match protocol.ErrUnexpectedStatus", err)
+				}
+				if filename != "" {
+					t.Errorf("filename = %q, want empty on error", filename)
+				}
+				assertEmptyDir(t, dir)
+			})
+		}
+	})
+
+	// A 200 carrying something that is not a JPEG is still stored: the driver does not
+	// inspect the bytes, and that success path is deliberately unchanged.
+	t.Run("a 200 with a non-image body is still stored", func(t *testing.T) {
+		const body = "<html>not an image</html>"
+		dir := t.TempDir()
+		cam, _ := newCam(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(body))
+		})
+		filename, err := cam.TakeSnapshot(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		content, err := os.ReadFile(filepath.Join(dir, filename))
+		if err != nil {
+			t.Fatalf("reading snapshot: %v", err)
+		}
+		if string(content) != body {
+			t.Errorf("stored content = %q, want %q", content, body)
+		}
+	})
+
 	t.Run("an unwritable output directory returns an error and no filename", func(t *testing.T) {
 		cam, _ := newCam(t, func(w http.ResponseWriter, r *http.Request) {
 			_, _ = w.Write([]byte("jpegbytes"))
@@ -148,10 +234,16 @@ func TestTakeSnapshot(t *testing.T) {
 		}
 	})
 
-	t.Run("an offline camera returns an error", func(t *testing.T) {
-		if _, err := offlineCam(t).TakeSnapshot(t.TempDir()); err == nil {
+	t.Run("an offline camera returns an error and leaves no file", func(t *testing.T) {
+		dir := t.TempDir()
+		filename, err := offlineCam(t).TakeSnapshot(dir)
+		if err == nil {
 			t.Error("expected an error from an unreachable camera")
 		}
+		if filename != "" {
+			t.Errorf("filename = %q, want empty on error", filename)
+		}
+		assertEmptyDir(t, dir)
 	})
 }
 

--- a/pkg/camera/panasonic/panasonic_test.go
+++ b/pkg/camera/panasonic/panasonic_test.go
@@ -1,13 +1,17 @@
 package panasonic
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/TUM-Dev/gocast/pkg/camera/protocol"
 )
 
 type recorder struct {
@@ -34,6 +38,24 @@ func offlineCam(t *testing.T) PanasonicCam {
 	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 	srv.Close()
 	return *NewPanasonicCam(strings.TrimPrefix(srv.URL, "http://"), "user:password")
+}
+
+// assertEmptyDir fails if anything was written into dir. A snapshot that failed must
+// leave nothing behind: whatever consumes lecture-hall snapshots cannot tell a stored
+// error page from a real JPEG.
+func assertEmptyDir(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading output directory: %v", err)
+	}
+	if len(entries) != 0 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("output directory contains %v, want no file at all", names)
+	}
 }
 
 func TestSetPreset(t *testing.T) {
@@ -68,13 +90,22 @@ func TestSetPreset(t *testing.T) {
 		})
 	}
 
-	// BUG: the status code is discarded, so a camera answering 401 or 500 looks like a
-	// successful preset change to every caller.
-	t.Run("a failing camera is reported as success", func(t *testing.T) {
+	// A camera that answers 401 or 500 has not moved. Reporting that as a successful preset
+	// change left an operator watching a stream that never changed angle, with nothing in
+	// the logs; the status is now an error naming the code.
+	t.Run("a failing camera returns an error", func(t *testing.T) {
 		for _, code := range []int{http.StatusInternalServerError, http.StatusUnauthorized} {
 			cam, _ := newCam(t, func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(code) })
-			if err := cam.SetPreset(1); err != nil {
-				t.Errorf("code %d: got error %v; if status handling was added, update this test", code, err)
+			err := cam.SetPreset(1)
+			if err == nil {
+				t.Errorf("code %d: expected an error, the camera did not move", code)
+				continue
+			}
+			if !errors.Is(err, protocol.ErrUnexpectedStatus) {
+				t.Errorf("code %d: error %v does not match protocol.ErrUnexpectedStatus", code, err)
+			}
+			if !strings.Contains(err.Error(), strconv.Itoa(code)) {
+				t.Errorf("code %d: error %q does not name the status code", code, err)
 			}
 		}
 	})
@@ -112,6 +143,79 @@ func TestTakeSnapshot(t *testing.T) {
 		}
 	})
 
+	// The regression worth locking down: an error response used to be written to disk as a
+	// .jpg and handed back as a valid snapshot filename.
+	t.Run("an error response leaves no file on disk", func(t *testing.T) {
+		cases := []struct {
+			name string
+			code int
+			body string
+		}{
+			{name: "500 with an html error page", code: http.StatusInternalServerError, body: "<html><body>Internal Server Error</body></html>"},
+			{name: "401 with an html error page", code: http.StatusUnauthorized, body: "<html><head><title>401 Unauthorized</title></head></html>"},
+			{name: "401 with an empty body", code: http.StatusUnauthorized, body: ""},
+		}
+		for _, tt := range cases {
+			t.Run(tt.name, func(t *testing.T) {
+				dir := t.TempDir()
+				cam, _ := newCam(t, func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(tt.code)
+					_, _ = w.Write([]byte(tt.body))
+				})
+				filename, err := cam.TakeSnapshot(dir)
+				if err == nil {
+					t.Fatalf("expected an error, got filename %q", filename)
+				}
+				if !errors.Is(err, protocol.ErrUnexpectedStatus) {
+					t.Errorf("error %v does not match protocol.ErrUnexpectedStatus", err)
+				}
+				if filename != "" {
+					t.Errorf("filename = %q, want empty on error", filename)
+				}
+				assertEmptyDir(t, dir)
+			})
+		}
+	})
+
+	// A 200 carrying something that is not a JPEG is still stored: the driver does not
+	// inspect the bytes, and that success path is deliberately unchanged.
+	t.Run("a 200 with a non-image body is still stored", func(t *testing.T) {
+		const body = "<html>not an image</html>"
+		dir := t.TempDir()
+		cam, _ := newCam(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(body))
+		})
+		filename, err := cam.TakeSnapshot(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		content, err := os.ReadFile(filepath.Join(dir, filename))
+		if err != nil {
+			t.Fatalf("reading snapshot: %v", err)
+		}
+		if string(content) != body {
+			t.Errorf("stored content = %q, want %q", content, body)
+		}
+	})
+
+	// An empty 200 body is what these cameras send while booting: unchanged behaviour, a
+	// zero-length file and no error.
+	t.Run("an empty body still produces a file and no error", func(t *testing.T) {
+		dir := t.TempDir()
+		cam, _ := newCam(t, func(w http.ResponseWriter, r *http.Request) {})
+		filename, err := cam.TakeSnapshot(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		info, err := os.Stat(filepath.Join(dir, filename))
+		if err != nil {
+			t.Fatalf("stat snapshot: %v", err)
+		}
+		if info.Size() != 0 {
+			t.Errorf("size = %d, want 0", info.Size())
+		}
+	})
+
 	t.Run("an unwritable output directory returns an error and no filename", func(t *testing.T) {
 		cam, _ := newCam(t, func(w http.ResponseWriter, r *http.Request) {
 			_, _ = w.Write([]byte("jpegbytes"))
@@ -125,10 +229,16 @@ func TestTakeSnapshot(t *testing.T) {
 		}
 	})
 
-	t.Run("an offline camera returns an error", func(t *testing.T) {
-		if _, err := offlineCam(t).TakeSnapshot(t.TempDir()); err == nil {
+	t.Run("an offline camera returns an error and leaves no file", func(t *testing.T) {
+		dir := t.TempDir()
+		filename, err := offlineCam(t).TakeSnapshot(dir)
+		if err == nil {
 			t.Error("expected an error from an unreachable camera")
 		}
+		if filename != "" {
+			t.Errorf("filename = %q, want empty on error", filename)
+		}
+		assertEmptyDir(t, dir)
 	})
 }
 

--- a/pkg/camera/protocol/protocol.go
+++ b/pkg/camera/protocol/protocol.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,9 +12,20 @@ import (
 	"github.com/icholy/digest"
 )
 
+// ErrUnexpectedStatus is returned when a camera answers with anything other than 200 OK.
+// Callers that need to react to an unreachable-but-answering camera (rather than to any
+// failure) can match it with errors.Is.
+var ErrUnexpectedStatus = errors.New("unexpected camera response status")
+
 // MakeAuthenticatedRequest Sends a request to the camera.
 // Example usage: c.makeAuthenticatedRequest("GET", "/base","/some.cgi?preset=1")
 // Returns the response body as a buffer.
+//
+// Anything other than 200 OK is an error: a camera that is powered down but still
+// answering, one that rejects the configured credentials, or one that fails internally
+// must not look like a successful preset change or a valid snapshot to the caller. The
+// status code is still returned alongside the error so callers can tell "unauthorized"
+// from "not found" without matching on the message.
 func MakeAuthenticatedRequest(auth *string, method string, body string, url string) (*bytes.Buffer, int, error) {
 	client := http.DefaultClient
 	// An empty credential means no credentials are configured for this camera type
@@ -55,6 +67,12 @@ func MakeAuthenticatedRequest(auth *string, method string, body string, url stri
 		_ = res.Body.Close()
 	}()
 
+	if res.StatusCode != http.StatusOK {
+		// The body is not read, let alone returned: an error page is not a snapshot, and
+		// handing it back is how it ended up on disk as a .jpg.
+		return nil, res.StatusCode, fmt.Errorf("camera %s: %w: %s", req.URL.Host, ErrUnexpectedStatus, res.Status)
+	}
+
 	bts, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, res.StatusCode, err
@@ -62,18 +80,25 @@ func MakeAuthenticatedRequest(auth *string, method string, body string, url stri
 	return bytes.NewBuffer(bts), res.StatusCode, nil
 }
 
-// SaveResponseBuffer saves the response buffer to a file
+// SaveResponseBuffer saves the response buffer to a file. A failed write leaves no
+// file behind: a truncated snapshot on disk is indistinguishable from a whole one for
+// everything downstream, so the partial file is removed instead.
 func SaveResponseBuffer(outDir string, filename string, resp *bytes.Buffer) error {
-	imageFile, err := os.Create(fmt.Sprintf("%s/%s", outDir, filename))
+	if resp == nil {
+		return fmt.Errorf("no response body to save to %s", filename)
+	}
+	path := fmt.Sprintf("%s/%s", outDir, filename)
+	imageFile, err := os.Create(path)
 	if err != nil {
 		return err
 	}
-	_, err = imageFile.Write(resp.Bytes())
-	if err != nil {
+	if _, err = imageFile.Write(resp.Bytes()); err != nil {
+		_ = imageFile.Close()
+		_ = os.Remove(path)
 		return err
 	}
-	err = imageFile.Close()
-	if err != nil {
+	if err = imageFile.Close(); err != nil {
+		_ = os.Remove(path)
 		return err
 	}
 	return nil

--- a/pkg/camera/protocol/protocol_test.go
+++ b/pkg/camera/protocol/protocol_test.go
@@ -3,12 +3,14 @@ package protocol
 import (
 	"bytes"
 	"crypto/md5"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -102,11 +104,11 @@ func TestMakeAuthenticatedRequest(t *testing.T) {
 		}
 	})
 
-	// A camera answering 500 or 401 is not reported as an error here; only the status
-	// code carries that information. Callers that drop the status (every driver's
-	// SetPreset does) therefore cannot tell failure from success -- pinned so the day
-	// someone adds status handling, the affected callers are found by a failing test.
-	t.Run("a non-200 response is returned without an error", func(t *testing.T) {
+	// A camera answering 500 or 401 has not done what was asked of it. The status alone
+	// used to carry that, and every driver dropped it, so failures read as successes; it is
+	// now an error as well, naming both the camera and the status so an operator can tell
+	// "wrong credentials" from "camera is broken".
+	t.Run("a non-200 response is an error naming the camera and the status", func(t *testing.T) {
 		for _, code := range []int{http.StatusInternalServerError, http.StatusUnauthorized, http.StatusNotFound} {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(code)
@@ -114,16 +116,40 @@ func TestMakeAuthenticatedRequest(t *testing.T) {
 			}))
 
 			buf, status, err := MakeAuthenticatedRequest(nil, "GET", "", srv.URL)
-			if err != nil {
-				t.Errorf("code %d: unexpected error: %v", code, err)
+			if err == nil {
+				t.Errorf("code %d: expected an error", code)
+			} else {
+				if !errors.Is(err, ErrUnexpectedStatus) {
+					t.Errorf("code %d: error %v does not match ErrUnexpectedStatus", code, err)
+				}
+				if !strings.Contains(err.Error(), strconv.Itoa(code)) {
+					t.Errorf("code %d: error %q does not name the status code", code, err)
+				}
+				if host := strings.TrimPrefix(srv.URL, "http://"); !strings.Contains(err.Error(), host) {
+					t.Errorf("code %d: error %q does not name the camera %q", code, err, host)
+				}
 			}
 			if status != code {
 				t.Errorf("status = %d, want %d", status, code)
 			}
-			if buf == nil || buf.String() != "failure body" {
-				t.Errorf("code %d: body not returned", code)
+			// The error page must not reach a caller that would write it out as a .jpg.
+			if buf != nil {
+				t.Errorf("code %d: buffer = %q, want nil alongside the error", code, buf.String())
 			}
 			srv.Close()
+		}
+	})
+
+	// A 2xx that is not exactly 200 is still treated as a failure: these vendor CGIs answer
+	// 200 on success, and anything else means the request did not do what was asked.
+	t.Run("a 204 is treated as a failure", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer srv.Close()
+
+		if _, status, err := MakeAuthenticatedRequest(nil, "GET", "", srv.URL); err == nil {
+			t.Errorf("status %d: expected an error", status)
 		}
 	})
 
@@ -293,6 +319,23 @@ func TestSaveResponseBuffer(t *testing.T) {
 		err := SaveResponseBuffer(filepath.Join(t.TempDir(), "does-not-exist"), "snap.jpg", bytes.NewBufferString("ignored"))
 		if err == nil {
 			t.Error("expected an error writing into a missing directory")
+		}
+	})
+
+	// MakeAuthenticatedRequest hands back a nil buffer alongside every error, so a caller
+	// that forgets to check it must get an error rather than a nil dereference that takes
+	// the whole process down.
+	t.Run("a nil buffer errors instead of panicking and writes nothing", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := SaveResponseBuffer(dir, "snap.jpg", nil); err == nil {
+			t.Error("expected an error for a nil buffer")
+		}
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("reading output directory: %v", err)
+		}
+		if len(entries) != 0 {
+			t.Errorf("output directory contains %d files, want none", len(entries))
 		}
 	})
 }

--- a/pkg/camera/sony/sonysrg.go
+++ b/pkg/camera/sony/sonysrg.go
@@ -2,7 +2,6 @@ package sony
 
 import (
 	"fmt"
-	"net/http"
 
 	uuid "github.com/satori/go.uuid"
 
@@ -51,8 +50,9 @@ func (s *SonySRG) GetPresets() ([]model.CameraPreset, error) {
 	// Sony SRG-A40 cameras support up to 256 presets, but only a few are used (see panasonic.go)
 	presets := make([]model.CameraPreset, 0, 16)
 	for i := range 16 {
-		_, status, err := protocol.MakeAuthenticatedRequest(&s.Auth, "GET", "", fmt.Sprintf("http://%s/preset/presetimg%d.jpg", s.Ip, i+1))
-		if err != nil || status != http.StatusOK {
+		// A missing thumbnail answers 404, which MakeAuthenticatedRequest reports as an
+		// error: the first failing probe ends the listing, as before.
+		if _, _, err := protocol.MakeAuthenticatedRequest(&s.Auth, "GET", "", fmt.Sprintf("http://%s/preset/presetimg%d.jpg", s.Ip, i+1)); err != nil {
 			break
 		}
 		presets = append(presets, model.CameraPreset{

--- a/pkg/camera/sony/sonysrg_test.go
+++ b/pkg/camera/sony/sonysrg_test.go
@@ -1,14 +1,18 @@
 package sony
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/TUM-Dev/gocast/pkg/camera/protocol"
 )
 
 type recorder struct {
@@ -46,6 +50,24 @@ func offlineCam(t *testing.T) *SonySRG {
 	return NewSonySRG(strings.TrimPrefix(srv.URL, "http://"), "user:password")
 }
 
+// assertEmptyDir fails if anything was written into dir. A snapshot that failed must
+// leave nothing behind: whatever consumes lecture-hall snapshots cannot tell a stored
+// error page from a real JPEG.
+func assertEmptyDir(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading output directory: %v", err)
+	}
+	if len(entries) != 0 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("output directory contains %v, want no file at all", names)
+	}
+}
+
 func TestSetPreset(t *testing.T) {
 	// The driver does no range checking; the SRG-A40 supports 256 presets but nothing
 	// here enforces that, which is pinned as current behaviour.
@@ -78,13 +100,22 @@ func TestSetPreset(t *testing.T) {
 		})
 	}
 
-	// BUG: the status code is discarded, so a camera answering 401 or 500 looks like a
-	// successful preset change to every caller.
-	t.Run("a failing camera is reported as success", func(t *testing.T) {
+	// A camera that answers 401 or 500 has not moved. Reporting that as a successful preset
+	// change left an operator watching a stream that never changed angle, with nothing in
+	// the logs; the status is now an error naming the code.
+	t.Run("a failing camera returns an error", func(t *testing.T) {
 		for _, code := range []int{http.StatusInternalServerError, http.StatusUnauthorized} {
 			cam, _ := newCam(t, func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(code) })
-			if err := cam.SetPreset(1); err != nil {
-				t.Errorf("code %d: got error %v; if status handling was added, update this test", code, err)
+			err := cam.SetPreset(1)
+			if err == nil {
+				t.Errorf("code %d: expected an error, the camera did not move", code)
+				continue
+			}
+			if !errors.Is(err, protocol.ErrUnexpectedStatus) {
+				t.Errorf("code %d: error %v does not match protocol.ErrUnexpectedStatus", code, err)
+			}
+			if !strings.Contains(err.Error(), strconv.Itoa(code)) {
+				t.Errorf("code %d: error %q does not name the status code", code, err)
 			}
 		}
 	})
@@ -122,6 +153,79 @@ func TestTakeSnapshot(t *testing.T) {
 		}
 	})
 
+	// The regression worth locking down: an error response used to be written to disk as a
+	// .jpg and handed back as a valid snapshot filename.
+	t.Run("an error response leaves no file on disk", func(t *testing.T) {
+		cases := []struct {
+			name string
+			code int
+			body string
+		}{
+			{name: "500 with an html error page", code: http.StatusInternalServerError, body: "<html><body>Internal Server Error</body></html>"},
+			{name: "401 with an html error page", code: http.StatusUnauthorized, body: "<html><head><title>401 Unauthorized</title></head></html>"},
+			{name: "401 with an empty body", code: http.StatusUnauthorized, body: ""},
+		}
+		for _, tt := range cases {
+			t.Run(tt.name, func(t *testing.T) {
+				dir := t.TempDir()
+				cam, _ := newCam(t, func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(tt.code)
+					_, _ = w.Write([]byte(tt.body))
+				})
+				filename, err := cam.TakeSnapshot(dir)
+				if err == nil {
+					t.Fatalf("expected an error, got filename %q", filename)
+				}
+				if !errors.Is(err, protocol.ErrUnexpectedStatus) {
+					t.Errorf("error %v does not match protocol.ErrUnexpectedStatus", err)
+				}
+				if filename != "" {
+					t.Errorf("filename = %q, want empty on error", filename)
+				}
+				assertEmptyDir(t, dir)
+			})
+		}
+	})
+
+	// A 200 carrying something that is not a JPEG is still stored: the driver does not
+	// inspect the bytes, and that success path is deliberately unchanged.
+	t.Run("a 200 with a non-image body is still stored", func(t *testing.T) {
+		const body = "<html>not an image</html>"
+		dir := t.TempDir()
+		cam, _ := newCam(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(body))
+		})
+		filename, err := cam.TakeSnapshot(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		content, err := os.ReadFile(filepath.Join(dir, filename))
+		if err != nil {
+			t.Fatalf("reading snapshot: %v", err)
+		}
+		if string(content) != body {
+			t.Errorf("stored content = %q, want %q", content, body)
+		}
+	})
+
+	// An empty 200 body is what these cameras send while booting: unchanged behaviour, a
+	// zero-length file and no error.
+	t.Run("an empty body still produces a file and no error", func(t *testing.T) {
+		dir := t.TempDir()
+		cam, _ := newCam(t, func(w http.ResponseWriter, r *http.Request) {})
+		filename, err := cam.TakeSnapshot(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		info, err := os.Stat(filepath.Join(dir, filename))
+		if err != nil {
+			t.Fatalf("stat snapshot: %v", err)
+		}
+		if info.Size() != 0 {
+			t.Errorf("size = %d, want 0", info.Size())
+		}
+	})
+
 	t.Run("an unwritable output directory returns an error and no filename", func(t *testing.T) {
 		cam, _ := newCam(t, func(w http.ResponseWriter, r *http.Request) {
 			_, _ = w.Write([]byte("jpegbytes"))
@@ -135,10 +239,16 @@ func TestTakeSnapshot(t *testing.T) {
 		}
 	})
 
-	t.Run("an offline camera returns an error", func(t *testing.T) {
-		if _, err := offlineCam(t).TakeSnapshot(t.TempDir()); err == nil {
+	t.Run("an offline camera returns an error and leaves no file", func(t *testing.T) {
+		dir := t.TempDir()
+		filename, err := offlineCam(t).TakeSnapshot(dir)
+		if err == nil {
 			t.Error("expected an error from an unreachable camera")
 		}
+		if filename != "" {
+			t.Errorf("filename = %q, want empty on error", filename)
+		}
+		assertEmptyDir(t, dir)
 	})
 }
 


### PR DESCRIPTION
## What was broken

`protocol.MakeAuthenticatedRequest` returned `(body, status, nil)` for **any** response it could read — 401 and 500 included. It handed the status back, and all three drivers dropped it on the floor (`_, _, err := ...; return err`).

Operator-visible consequences on real lecture-hall hardware:

- **`SetPreset` silently lied.** A camera that was unauthorized, erroring, or powered down but still answering reported a *successful preset change*. The operator saw success in the UI; the camera never moved, and nothing landed in the logs.
- **`TakeSnapshot` was worse.** The 401/500 HTML error page was written to disk as a `.jpg` and its filename returned as a valid snapshot, so a corrupt "image" flowed onward to everything that consumes lecture-hall snapshots.

## Where the check went, and why

**Centrally, in `MakeAuthenticatedRequest`.** Every caller gets it for free, there is exactly one definition of "the camera did not do what was asked", and no future driver can forget it. Per-driver checks would have meant three copies of the same three lines with three chances to diverge — and the original bug was precisely that each driver independently ignored the status.

Anything other than 200 now returns an error wrapping an exported sentinel:

```
camera 10.0.0.5:80: unexpected camera response status: 401 Unauthorized
```

The message names **the camera and the status**, because the operational question is always "which camera, and is this auth or is it down". `errors.Is(err, protocol.ErrUnexpectedStatus)` distinguishes "answered, but badly" from a transport failure. The error is built with `fmt.Errorf` + `%w`, matching the rest of the package.

The status is checked *before* the body is read, and **no body is returned alongside the error** — an error page is not a snapshot, and returning it is exactly how it ended up on disk.

## Signature

**Unchanged:** `(*bytes.Buffer, int, error)`. The status is still useful to callers that want to tell 401 from 404 without matching on a message, and it is asserted in existing tests in `pkg/camera`. Removing it would have churned every call site for no behavioural gain.

Sony's `GetPresets` was the only place that checked the status (`err != nil || status != http.StatusOK`); that check is now redundant and simplifies to `if err != nil { break }`. Its stop-at-the-first-missing-thumbnail behaviour, and therefore the number of presets a lecture hall shows, is unchanged.

## Other changes

- `SaveResponseBuffer` removes a partially written file when the write or close fails — a truncated snapshot on disk is indistinguishable from a whole one downstream — and rejects a `nil` buffer with an error instead of panicking.
- No ordering fix was needed in the drivers: all three already check the error before saving, so the central error is enough to stop the file being created at all.
- **The 200 path is byte-for-byte unchanged.** This hardware cannot be tested here, so the success path was deliberately left alone; a test pins that a 200 carrying a non-image body is still stored exactly as before.

## Tests

The tests that *pinned* the buggy behaviour were rewritten rather than deleted: "a failing camera is reported as success" is now "a failing camera returns an error", and the protocol test asserting a non-200 returns no error now asserts the error, the sentinel, the status code and the host in the message.

Per driver there is now coverage for 500, 401, an empty body, a malformed/HTML body, and a connection failure — plus the regression most worth locking down: **`TakeSnapshot` leaves no file on disk at all** when the camera errors (asserted by reading the output directory, not just by the returned filename), including for an offline camera.

`go test -race -count=2 ./pkg/...`, `go vet ./pkg/...` and `gofmt -l pkg/camera/` are all clean.

## Stacking

This is stacked on **#1956** (`fix/camera-auth-panic`), which is itself stacked on **#1955** (`test/cover-model-tools-camera`). It is based there because #1956 already edits `protocol.go` and its tests. GitHub will retarget this PR automatically as the stack merges down. The auth-parsing tests from #1956 are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
