### PR TITLE
fix(tools): stop TruncateHtml panicking on trailing multi-byte runes and stray "<"

### DIFF
--- a/tools/truncate.go
+++ b/tools/truncate.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"regexp"
@@ -91,8 +92,11 @@ func TruncateHtml(buf []byte, maxlen int, ellipsis string) ([]byte, error) {
 		bufPtr += offset
 
 		// Stop scanning if the end of the buffer was reached or if the max
-		// desired visible characters was reached
-		if visibleCharacterMaxReached || bufPtr >= len(buf)-1 {
+		// desired visible characters was reached. bufPtr is a byte offset pointing
+		// at the *start* of a rune, so the end of the buffer is one whole rune --
+		// not one byte -- past it.
+		_, lastRuneSize := utf8.DecodeRune(buf[bufPtr:])
+		if visibleCharacterMaxReached || bufPtr+lastRuneSize >= len(buf) {
 			break
 		}
 
@@ -105,6 +109,18 @@ func TruncateHtml(buf []byte, maxlen int, ellipsis string) ([]byte, error) {
 
 		// Now find the expression sub-matches
 		matches := TagExpr.FindSubmatch(buf[bufPtr:])
+		if matches == nil || !bytes.HasPrefix(buf[bufPtr:], matches[0]) {
+			// TagExpr is unanchored, so a match that does not start at bufPtr belongs
+			// to some later tag. Either way this '<' does not open a tag -- it is
+			// literal text ("5 < 10") or a comment. Count it as a visible character
+			// and keep scanning past it.
+			visible++
+			if visible >= maxlen {
+				break
+			}
+			bufPtr++
+			continue
+		}
 		tagName := string(matches[2])
 
 		// Advance pointer to the end of the tag

--- a/tools/truncate_test.go
+++ b/tools/truncate_test.go
@@ -263,12 +263,44 @@ func TestTruncateHtml(t *testing.T) {
 		},
 		{
 			// A trailing "<" never reaches the tag parser because the scan stops at the
-			// end of the buffer first; contrast with TestTruncateHtmlStrayLessThanPanics.
+			// end of the buffer first; contrast with TestTruncateHtmlStrayLessThan.
 			name:     "a trailing stray less-than is copied through",
 			in:       "<",
 			maxlen:   3,
 			ellipsis: "...",
 			want:     "<...",
+		},
+		{
+			name:     "a lone less-than as the very last byte is copied through",
+			in:       "abc<",
+			maxlen:   10,
+			ellipsis: "...",
+			want:     "abc<...",
+		},
+		{
+			// The prose around the "<" must survive: a stray "<" is literal text and
+			// counts against the visible budget like any other character.
+			name:     "a stray less-than mid-text counts as one visible character",
+			in:       "5 < 10 and 3 > 1 blah",
+			maxlen:   5,
+			ellipsis: "...",
+			want:     "5 < 10 a...",
+		},
+		{
+			// TagExpr is unanchored, so the stray "<" must not be resolved against the
+			// real <b> further along the input.
+			name:     "a stray less-than does not steal a later tag",
+			in:       "<b>5 < 10</b> abc",
+			maxlen:   100,
+			ellipsis: "...",
+			want:     "<b>5 < 10</b> abc...",
+		},
+		{
+			name:     "an html comment is treated as visible text, not as markup",
+			in:       "<!-- a comment -->abcdef",
+			maxlen:   5,
+			ellipsis: "...",
+			want:     "<!-- a...",
 		},
 	}
 
@@ -294,43 +326,115 @@ func TestTruncateHtml(t *testing.T) {
 	}
 }
 
-// BUG: a "<" that does not start a tag makes TagExpr.FindSubmatch return nil, which is
-// then indexed unguarded. "5 < 10" or an HTML comment in a course description crashes
-// the request. Pinned as a panic so a fix turns this test red rather than passing
-// silently.
-func TestTruncateHtmlStrayLessThanPanics(t *testing.T) {
-	inputs := []string{
-		"a < b and more text",
-		"5 < 10 and 3 > 1 blah",
-		"<!-- a comment -->abcdef",
+// A "<" that does not start a tag used to make TagExpr.FindSubmatch return nil, which
+// was then indexed unguarded: "5 < 10" or an HTML comment in a course description
+// crashed the request. Such a "<" is literal text and is now counted as one visible
+// character and copied through.
+func TestTruncateHtmlStrayLessThan(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		maxlen   int
+		ellipsis string
+		want     string
+	}{
+		{
+			name:     "a stray less-than between words",
+			in:       "a < b and more text",
+			maxlen:   5,
+			ellipsis: "...",
+			want:     "a < b an...",
+		},
+		{
+			name:     "a stray less-than that fits inside the budget",
+			in:       "a < b",
+			maxlen:   100,
+			ellipsis: "...",
+			want:     "a < b...",
+		},
+		{
+			name:     "a comparison with a greater-than later in the text",
+			in:       "5 < 10 and 3 > 1 blah",
+			maxlen:   5,
+			ellipsis: "...",
+			want:     "5 < 10 a...",
+		},
+		{
+			name:     "an html comment is cut like ordinary text",
+			in:       "<!-- a comment -->abcdef",
+			maxlen:   5,
+			ellipsis: "...",
+			want:     "<!-- a...",
+		},
+		{
+			name:     "an html comment that fits is copied through whole",
+			in:       "<!-- a comment -->abcdef",
+			maxlen:   100,
+			ellipsis: "...",
+			want:     "<!-- a comment -->abcdef...",
+		},
+		{
+			name:     "a lone less-than as the very last byte",
+			in:       "abc<",
+			maxlen:   100,
+			ellipsis: "...",
+			want:     "abc<...",
+		},
 	}
-	for _, in := range inputs {
-		t.Run(in, func(t *testing.T) {
-			defer func() {
-				if r := recover(); r == nil {
-					t.Errorf("TruncateHtml(%q) no longer panics; the nil-match crash appears fixed, update this test", in)
-				}
-			}()
-			_, _ = TruncateHtml([]byte(in), 5, "...")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := TruncateHtml([]byte(tt.in), tt.maxlen, tt.ellipsis)
+			if err != nil {
+				t.Fatalf("TruncateHtml(%q, %d) returned unexpected error %v", tt.in, tt.maxlen, err)
+			}
+			if string(got) != tt.want {
+				t.Errorf("TruncateHtml(%q, %d) = %q, want %q", tt.in, tt.maxlen, got, tt.want)
+			}
 		})
 	}
 }
 
-// BUG: the end-of-buffer check compares bufPtr against len(buf)-1, which only holds
+// The end-of-buffer check used to compare bufPtr against len(buf)-1, which only holds
 // when the final rune is one byte wide. An input whose last rune is multi-byte and
-// whose budget is not exhausted before it falls through to the tag parser with no tag
-// left to match, and crashes. Only the final rune decides, so "Grüße" is safe and "bä"
-// is not -- which is how this survived unnoticed in a German university's codebase.
-func TestTruncateHtmlPanicsOnTrailingMultiByteRune(t *testing.T) {
-	inputs := []string{"ä", "bä", "ö", "😀", "中", "Vorlesung über Prüfungsordnungä"}
-	for _, in := range inputs {
-		t.Run(in, func(t *testing.T) {
-			defer func() {
-				if r := recover(); r == nil {
-					t.Errorf("TruncateHtml(%q) no longer panics; the end-of-buffer check appears fixed, update this test", in)
-				}
-			}()
-			_, _ = TruncateHtml([]byte(in), 100, "...")
+// whose budget is not exhausted before it fell through to the tag parser with no tag
+// left to match, and crashed. Only the final rune decided, so "Gruesse" spelled with a
+// sharp s was safe and "ba" with an umlaut was not -- which is how this survived
+// unnoticed in a German university's codebase. The guard now measures the width of the
+// rune at bufPtr, so such input is returned whole.
+func TestTruncateHtmlTrailingMultiByteRune(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     string
+		maxlen int
+		want   string
+	}{
+		{name: "a lone umlaut", in: "ä", maxlen: 100, want: "ä..."},
+		{name: "an umlaut after an ascii byte", in: "bä", maxlen: 100, want: "bä..."},
+		{name: "a lone o umlaut", in: "ö", maxlen: 100, want: "ö..."},
+		{name: "a lone four-byte emoji", in: "😀", maxlen: 100, want: "😀..."},
+		{name: "a lone cjk character", in: "中", maxlen: 100, want: "中..."},
+		{name: "two cjk characters", in: "中文", maxlen: 100, want: "中文..."},
+		{name: "a german title ending in an umlaut", in: "Vorlesung über Prüfungsordnungä", maxlen: 100, want: "Vorlesung über Prüfungsordnungä..."},
+		{name: "a title ending in an emoji", in: "Prüfung 😀", maxlen: 100, want: "Prüfung 😀..."},
+		{name: "an em dash terminator", in: "Analysis —", maxlen: 100, want: "Analysis —..."},
+		{name: "a typographic quote terminator", in: "sogenannte „Klausur“", maxlen: 100, want: "sogenannte „Klausur“..."},
+		{name: "an ascii terminator still behaves as before", in: "Grüße", maxlen: 100, want: "Grüße..."},
+		{name: "markup is still closed when the input ends in an umlaut", in: "<b>bä", maxlen: 100, want: "<b>bä...</b>"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := TruncateHtml([]byte(tt.in), tt.maxlen, "...")
+			if err != nil {
+				t.Fatalf("TruncateHtml(%q, %d) returned unexpected error %v", tt.in, tt.maxlen, err)
+			}
+			if string(got) != tt.want {
+				t.Errorf("TruncateHtml(%q, %d) = %q, want %q", tt.in, tt.maxlen, got, tt.want)
+			}
+			if !utf8.Valid(got) {
+				t.Errorf("TruncateHtml(%q, %d) produced invalid UTF-8: %q", tt.in, tt.maxlen, got)
+			}
 		})
 	}
 }
@@ -416,6 +520,7 @@ func TestTruncateHtmlPropertiesOnGeneratedInput(t *testing.T) {
 	tokens := []string{
 		"a", "b", " ", "  ", "ä", "ö", "ß", "😀", "中", "&amp;", "&#8212;", "&",
 		"<b>", "</b>", "<i>", "</i>", "<br>", "<hr/>", `<img src="x">`, "\n", "\t",
+		"<", " < ", "<!-- c -->",
 	}
 	const ellipsis = "…"
 
@@ -425,10 +530,6 @@ func TestTruncateHtmlPropertiesOnGeneratedInput(t *testing.T) {
 		for n := rng.Intn(12); n >= 0; n-- {
 			sb.WriteString(tokens[rng.Intn(len(tokens))])
 		}
-		// Every input is terminated with an ASCII byte: an input ending in a multi-byte
-		// rune crashes (see TestTruncateHtmlPanicsOnTrailingMultiByteRune), which would
-		// otherwise mask every other property this loop checks.
-		sb.WriteString("z")
 		in := sb.String()
 		maxlen := rng.Intn(12)
 


### PR DESCRIPTION
`tools.TruncateHtml` is fed lecture and course descriptions, which are user-supplied. Two classes of perfectly ordinary input made it panic with `index out of range [2] with length 0` at the unguarded `TagExpr.FindSubmatch(buf[bufPtr:])[2]` on `tools/truncate.go:108`, taking down the request that rendered them.

## Panic 1 — any input ending in a multi-byte rune

**Root cause: a byte offset compared against a rune-width assumption.** The end-of-scan guard read

```go
if visibleCharacterMaxReached || bufPtr >= len(buf)-1 {
```

`bufPtr` is a **byte** offset, and after the inner scan it points at the **start** of the last rune. `len(buf)-1` is therefore only the end of the buffer when that final rune happens to be one byte wide. With a wider final rune the guard never fired; the loop fell through to the tag parser with no tag left in the buffer, `FindSubmatch` returned `nil`, and `matches[2]` panicked.

Because only the *final* rune decides, the bug is invisible most of the time: `"Grüße"` is fine (ends in ASCII `e`), `"bä"` crashes.

Reproducer:

```go
tools.TruncateHtml([]byte("bä"), 20, "...") // panic: index out of range [2] with length 0
```

In practice: a description ending in an umlaut, an em dash, a typographic quote (`„Klausur“`) or an emoji. In a German university's codebase that is not an edge case.

**Fix.** Measure the width of the rune actually sitting at `bufPtr` and compare against `len(buf)`:

```go
_, lastRuneSize := utf8.DecodeRune(buf[bufPtr:])
if visibleCharacterMaxReached || bufPtr+lastRuneSize >= len(buf) {
```

For a one-byte final rune this is bit-for-bit the old condition, so nothing that worked before changes. **Fixed behaviour:** `TruncateHtml([]byte("bä"), 20, "...")` returns `"bä..."`; `"Vorlesung über Prüfungsordnungä"` comes back whole.

## Panic 2 — a `<` that does not open a tag

The scanner breaks out of its inner loop on **every** `<`, but `TagExpr` (`<(/?)([A-Za-z0-9]+).*?>`) requires an alphanumeric tag name immediately after it. A `<` used as a comparison operator, or the `<!` of an HTML comment, matches nothing, so `FindSubmatch` returned `nil` and was indexed just the same.

Reproducers: `"5 < 10 and 3 > 1"`, `"a < b"`, `"<!-- a comment -->abcdef"`.

**Fix.** Guard the match and treat such a `<` as what it is — literal text. It counts as one visible character against the budget and is copied through; scanning continues past it rather than terminating:

```go
matches := TagExpr.FindSubmatch(buf[bufPtr:])
if matches == nil || !bytes.HasPrefix(buf[bufPtr:], matches[0]) {
    visible++
    if visible >= maxlen {
        break
    }
    bufPtr++
    continue
}
```

The `bytes.HasPrefix` half is deliberate and worth calling out. `TagExpr` is **unanchored**, so on `"<b>5 < 10</b> abc"` the stray `<` would find the *later* `</b>` and advance `bufPtr` into the middle of the text, silently mis-parsing and corrupting the output rather than panicking. Requiring the match to start at `bufPtr` is what makes "count it as a character" actually true; it mirrors the `loc[0] == 0` check the entity branch a few lines above already does. `bufPtr` always points at a real tag in the non-stray case, so no existing behaviour moves.

**Fixed behaviour:** `TruncateHtml([]byte("5 < 10 and 3 > 1 blah"), 5, "...")` returns `"5 < 10 a..."`; `"<b>5 < 10</b> abc"` under a generous budget round-trips unchanged.

## Is letting a literal `<` through an injection risk?

**No.** Concretely:

- `TruncateHtml` is not, and never was, a sanitiser. It copies its input verbatim — a `<script>` in a description already passes straight through untouched, and did before this change. Letting a `<` that is *not* markup through adds nothing an attacker could not already do with a `<` that is.
- The templates are `html/template` (`web/router.go`), which escapes contextually. Output used as a plain string is escaped to `&lt;`; output that is escaping-exempt would have been exempt for the real tags too. The security posture is unchanged either way.
- The one cosmetic wrinkle: cutting inside a comment can emit an unterminated `<!-- a...`, which a browser would treat as swallowing what follows. That is a rendering artefact of truncating markup at all (the same class as the pre-existing uppercase-`</BR>` bug pinned in the tests), not a new escape hatch, and fixing it means teaching the scanner about comments — out of scope for a panic fix.

Net: this converts two crashes into the pass-through behaviour the function already had for every other byte. If sanitisation is wanted, it belongs in a separate pass, not here.

## Tests

`tools/truncate_test.go` on the base branch pins both panics. Rather than deleting those tests, they are rewritten to assert the corrected output:

- `TestTruncateHtmlStrayLessThanPanics` → `TestTruncateHtmlStrayLessThan`
- `TestTruncateHtmlPanicsOnTrailingMultiByteRune` → `TestTruncateHtmlTrailingMultiByteRune`

Added coverage for the newly reachable inputs: a stray `<` mid-text, a stray `<` that must not steal a later tag, an HTML comment (both cut and whole), a lone `<` as the very last byte, and input terminating in an umlaut / emoji / CJK character / em dash / typographic quote.

`TestTruncateHtmlPropertiesOnGeneratedInput` no longer appends the ASCII terminator that existed solely to dodge panic 1, and its token set gained `<`, ` < ` and `<!-- c -->`, so the 2000 generated inputs now exercise both fixed paths. Every other test in the file is untouched — several pin separate, still-open bugs (unconditional ellipsis, case-sensitive void-element list, `Truncate`'s swallowed error) that are out of scope here.

```
go test -race -count=2 ./tools/   ok
go vet ./tools/                   clean
gofmt -l tools/                   clean
```

---

Built on top of #1955, which is where the pinning tests live. That PR has since been squash-merged into `dev` (c8fe463) and its branch deleted, so this targets `dev` directly rather than `test/cover-model-tools-camera` — no retargeting is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
