### PR TITLE
fix(camera): don't panic on camera credentials without a colon

### DIFF
--- a/pkg/camera/controler_test.go
+++ b/pkg/camera/controler_test.go
@@ -1,11 +1,14 @@
 package camera
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/TUM-Dev/gocast/model"
 	"github.com/TUM-Dev/gocast/pkg/camera/axis"
 	"github.com/TUM-Dev/gocast/pkg/camera/panasonic"
+	"github.com/TUM-Dev/gocast/pkg/camera/protocol"
 	"github.com/TUM-Dev/gocast/pkg/camera/sony"
 )
 
@@ -89,9 +92,10 @@ func TestServiceFor(t *testing.T) {
 		}
 	})
 
-	// BUG: a camera type with no configured credentials yields an empty auth string,
-	// which protocol.MakeAuthenticatedRequest then splits on ":" and indexes at 1 --
-	// panicking on the first request. The factory itself still succeeds.
+	// A camera type with no configured credentials yields an empty auth string. The factory
+	// deliberately succeeds: protocol.MakeAuthenticatedRequest treats an empty credential as
+	// "no credentials configured" and sends the request unauthenticated, which some halls
+	// legitimately need. It used to index the ":"-split at 1 and panic on the first request.
 	t.Run("a camera type without credentials yields an empty auth rather than an error", func(t *testing.T) {
 		c, err := NewService(map[model.CameraType]string{}).For("10.0.0.1", model.Axis)
 		if err != nil {
@@ -101,8 +105,24 @@ func TestServiceFor(t *testing.T) {
 		if !ok {
 			t.Fatalf("got %T, want *axis.AxisCam", c)
 		}
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if got := r.Header.Get("Authorization"); got != "" {
+				t.Errorf("Authorization header = %q, want none", got)
+			}
+			_, _ = w.Write([]byte("anon"))
+		}))
+		defer srv.Close()
+
 		if cam.Auth != "" {
-			t.Errorf("auth = %q, want empty (see BUG note)", cam.Auth)
+			t.Errorf("auth = %q, want empty", cam.Auth)
+		}
+		// The empty credential must survive a real request without panicking.
+		buf, status, err := protocol.MakeAuthenticatedRequest(&cam.Auth, "GET", "", srv.URL)
+		if err != nil {
+			t.Fatalf("unexpected error requesting with an empty credential: %v", err)
+		}
+		if status != http.StatusOK || buf.String() != "anon" {
+			t.Errorf("got (%q, %d), want (%q, 200)", buf.String(), status, "anon")
 		}
 	})
 

--- a/pkg/camera/protocol/protocol.go
+++ b/pkg/camera/protocol/protocol.go
@@ -16,8 +16,15 @@ import (
 // Returns the response body as a buffer.
 func MakeAuthenticatedRequest(auth *string, method string, body string, url string) (*bytes.Buffer, int, error) {
 	client := http.DefaultClient
-	if auth != nil {
-		userPassword := strings.Split(*auth, ":")
+	// An empty credential means no credentials are configured for this camera type
+	// (camera.Service.For yields "" for a type missing from the auths map): talk to the
+	// camera unauthenticated. A non-empty credential must be "user:password"; anything
+	// else is a misconfiguration and is reported instead of being silently ignored.
+	if auth != nil && *auth != "" {
+		userPassword := strings.SplitN(*auth, ":", 2)
+		if len(userPassword) != 2 {
+			return nil, http.StatusBadRequest, fmt.Errorf("malformed camera credentials: expected \"user:password\"")
+		}
 		client = &http.Client{
 			Transport: &digest.Transport{
 				Username: userPassword[0],

--- a/pkg/camera/protocol/protocol_test.go
+++ b/pkg/camera/protocol/protocol_test.go
@@ -2,11 +2,14 @@ package protocol
 
 import (
 	"bytes"
+	"crypto/md5"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -159,23 +162,107 @@ func TestMakeAuthenticatedRequest(t *testing.T) {
 		}
 	})
 
-	// BUG: the auth string is split on ":" and index 1 is read unconditionally, so any
-	// credential without a colon panics. camera.Service.For passes "" for a camera type
-	// that has no configured credentials, which makes this reachable from configuration
-	// alone. Pinned as current behaviour, not endorsed.
-	t.Run("a credential without a colon panics", func(t *testing.T) {
-		for _, auth := range []string{"", "userwithoutcolon"} {
-			func() {
-				defer func() {
-					if recover() == nil {
-						t.Errorf("auth %q: expected a panic (see BUG note); it no longer panics -- update this test", auth)
-					}
-				}()
-				a := auth
-				_, _, _ = MakeAuthenticatedRequest(&a, "GET", "", closedServerURL(t))
-			}()
+	// camera.Service.For hands out "" for a camera type missing from the auths map, so an
+	// empty credential is a configuration state, not malformed input: the request goes out
+	// unauthenticated rather than panicking or erroring.
+	t.Run("an empty credential sends an unauthenticated request", func(t *testing.T) {
+		auth := ""
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if got := r.Header.Get("Authorization"); got != "" {
+				t.Errorf("Authorization header = %q, want none", got)
+			}
+			_, _ = w.Write([]byte("anon"))
+		}))
+		defer srv.Close()
+
+		buf, status, err := MakeAuthenticatedRequest(&auth, "GET", "", srv.URL)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if status != http.StatusOK || buf.String() != "anon" {
+			t.Errorf("got (%q, %d), want (%q, 200)", buf.String(), status, "anon")
 		}
 	})
+
+	// A non-empty credential that is not "user:password" is a misconfiguration: it is
+	// reported rather than silently downgraded to an unauthenticated request, and it must
+	// never panic -- an unrecovered panic in a handler goroutine takes the server down.
+	t.Run("a credential without a colon errors instead of panicking", func(t *testing.T) {
+		auth := "userwithoutcolon"
+		buf, status, err := MakeAuthenticatedRequest(&auth, "GET", "", closedServerURL(t))
+		if err == nil {
+			t.Fatal("expected an error for a credential without a colon")
+		}
+		if buf != nil {
+			t.Errorf("buffer = %v, want nil", buf)
+		}
+		if status != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400", status)
+		}
+	})
+
+	t.Run("a credential with an empty password is accepted", func(t *testing.T) {
+		auth := "user:"
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("done"))
+		}))
+		defer srv.Close()
+
+		buf, status, err := MakeAuthenticatedRequest(&auth, "GET", "", srv.URL)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if status != http.StatusOK || buf.String() != "done" {
+			t.Errorf("got (%q, %d), want (%q, 200)", buf.String(), status, "done")
+		}
+	})
+
+	// A colon is a legal password character, so only the first one separates the pair: the
+	// password "pa:ss" must arrive whole rather than truncated to "pa".
+	t.Run("a password containing a colon is kept whole", func(t *testing.T) {
+		auth := "user:pa:ss"
+		const realm, nonce = "camera", "deadbeef"
+		var gotUser, gotResponse string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			hdr := r.Header.Get("Authorization")
+			if hdr == "" {
+				w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Digest realm=%q, nonce=%q`, realm, nonce))
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			gotUser = digestParam(hdr, "username")
+			gotResponse = digestParam(hdr, "response")
+			_, _ = w.Write([]byte("done"))
+		}))
+		defer srv.Close()
+
+		if _, _, err := MakeAuthenticatedRequest(&auth, "GET", "", srv.URL); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if gotUser != "user" {
+			t.Errorf("username = %q, want %q", gotUser, "user")
+		}
+		ha1 := md5hex("user:" + realm + ":pa:ss")
+		ha2 := md5hex("GET:/")
+		if want := md5hex(ha1 + ":" + nonce + ":" + ha2); gotResponse != want {
+			t.Errorf("digest response = %q, want %q (password truncated at the colon?)", gotResponse, want)
+		}
+	})
+}
+
+func md5hex(s string) string {
+	return fmt.Sprintf("%x", md5.Sum([]byte(s)))
+}
+
+// digestParam pulls one quoted parameter out of a Digest Authorization header.
+func digestParam(header, key string) string {
+	for _, part := range strings.Split(strings.TrimPrefix(header, "Digest "), ",") {
+		kv := strings.SplitN(strings.TrimSpace(part), "=", 2)
+		if len(kv) == 2 && kv[0] == key {
+			return strings.Trim(kv[1], `"`)
+		}
+	}
+	return ""
 }
 
 func TestSaveResponseBuffer(t *testing.T) {


### PR DESCRIPTION
## Root cause

`protocol.MakeAuthenticatedRequest` did:

```go
userPassword := strings.Split(*auth, ":")
// ...
Password: userPassword[1],
```

`strings.Split` on a string with no colon returns a 1-element slice, so `userPassword[1]` is an index-out-of-range panic.

## How configuration reaches it

This is not reachable only from malformed input — it is reachable from ordinary configuration:

- `camera.Service.For` (`pkg/camera/controler.go`) sets `auth = ""` when the camera type is missing from the `auths` map.
- Every driver (`axis`, `panasonic`, `sony`) passes `&c.Auth`, never `nil`, so the `auth != nil` guard never helped.

So a lecture hall whose camera type has no configured credentials panicked on its first PTZ / snapshot / preset request. That code runs in a handler goroutine, and an **unrecovered panic in a goroutine takes the whole process down** — this was an availability bug, not a 500 on one request.

## Decision: error vs. unauthenticated

Two distinct cases, handled differently:

- **Empty credential → proceed unauthenticated.** This is the state the config path actually produces, and it is a legitimate one: a camera with no credentials configured may genuinely need an unauthenticated request. Erroring here would break those halls, and it is not a typo — it is the absence of a setting.
- **Non-empty credential without a colon → return an error.** There is no sensible interpretation of `"somesecret"` as a user/password pair. Silently downgrading it to an unauthenticated request would paper over a real misconfiguration and surface later as a confusing auth failure against the camera, so it is reported as a `400` with a clear message.

## Colon in the password

The old code also got this wrong in a second way: `strings.Split` yields more than two fields for `"user:pa:ss"`, and `userPassword[1]` silently truncated the password to `"pa"`. Now `strings.SplitN(*auth, ":", 2)` keeps everything after the first colon as the password. A colon is a legal password character, so this was a real (silent) auth failure for anyone using one.

## Tests

The two tests that pinned the buggy behaviour were rewritten to assert the correct behaviour rather than deleted:

- `pkg/camera/protocol/protocol_test.go`: the `recover()`-based "a credential without a colon panics" test is replaced with cases for an empty credential (unauthenticated request, no `Authorization` header), a credential with no colon (400 + error, no panic), an empty password (`"user:"`, accepted), a password containing a colon (`"user:pa:ss"`, verified end-to-end through a real digest challenge so truncation fails the test), and a normal credential.
- `pkg/camera/controler_test.go`: the matching factory test now also drives a real request with the empty auth the factory hands out, proving the config path no longer panics.

The unrelated "non-200 treated as success" pin in the same package is deliberately left untouched — that is a separate PR.

## Verification

`go test -race -count=2 ./pkg/...`, `go vet ./pkg/...` and `gofmt -l pkg/camera/` are all clean. The colon-in-password test was mutation-checked: reverting `SplitN` to `Split` makes it fail.

## Base branch

This targets #1955 (`test/cover-model-tools-camera`), whose tests pinned this bug. GitHub will retarget it to `dev` automatically once #1955 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

Replaces #1956, which was branched off the pre-squash base of #1955 and so conflicted with `dev`. Same commit, rebased onto current `dev`.
