### PR TITLE
fix(security): stop course names from steering filesystem paths

### DIFF
--- a/api/stream.go
+++ b/api/stream.go
@@ -24,6 +24,7 @@ import (
 	"github.com/TUM-Dev/gocast/pkg/runner_manager"
 	"github.com/TUM-Dev/gocast/tools"
 	"github.com/TUM-Dev/gocast/tools/bot"
+	"github.com/TUM-Dev/gocast/tools/safepath"
 	"github.com/TUM-Dev/gocast/voice-service/pb"
 )
 
@@ -701,13 +702,25 @@ func (r streamRoutes) newAttachment(c *gin.Context) {
 		filename = file.Filename
 		fileUuid := uuid.NewV1()
 
-		filesFolder := fmt.Sprintf("%s/%s.%d/%s.%s/files",
-			tools.Cfg.Paths.Mass,
-			course.Name, course.Year,
-			course.Name, course.TeachingTerm)
-		path = fmt.Sprintf("%s/%s%s", filesFolder, fileUuid, filepath.Ext(file.Filename))
+		// The course name is free text, so it is sanitized before it becomes a
+		// directory name - otherwise a name containing path elements would
+		// place the upload outside of the mass storage directory.
+		filesFolder, err := safepath.JoinInRoot(tools.Cfg.Paths.Mass,
+			fmt.Sprintf("%s.%d", course.Name, course.Year),
+			fmt.Sprintf("%s.%s", course.Name, course.TeachingTerm),
+			"files")
+		if err != nil {
+			logger.Error("could not build attachment folder", "err", err)
+			_ = c.Error(tools.RequestError{
+				Status:        http.StatusInternalServerError,
+				CustomMessage: "couldn't create folder for attachment",
+				Err:           err,
+			})
+			return
+		}
+		path = filepath.Join(filesFolder, fmt.Sprintf("%s%s", fileUuid, filepath.Ext(file.Filename)))
 
-		err = os.MkdirAll(filesFolder, os.ModePerm)
+		err = os.MkdirAll(filesFolder, 0o755)
 		if err != nil {
 			_ = c.Error(tools.RequestError{
 				Status:        http.StatusInternalServerError,
@@ -969,12 +982,23 @@ func (r streamRoutes) putCustomLiveThumbnail(c *gin.Context) {
 		return
 	}
 
-	filesFolder := filepath.Join(
+	// See newAttachment: the course name is free text and must not be able to
+	// steer the thumbnail out of the mass storage directory.
+	filesFolder, err := safepath.JoinInRoot(
 		tools.Cfg.Paths.Mass,
 		fmt.Sprintf("%s.%d.%s", course.Name, course.Year, course.TeachingTerm),
 		"files")
+	if err != nil {
+		logger.Error("could not build thumbnail folder", "err", err)
+		_ = c.AbortWithError(http.StatusInternalServerError, tools.RequestError{
+			Status:        http.StatusInternalServerError,
+			CustomMessage: "Failed to create thumbnail folder",
+			Err:           err,
+		})
+		return
+	}
 
-	if err := os.MkdirAll(filesFolder, os.ModePerm); err != nil {
+	if err := os.MkdirAll(filesFolder, 0o755); err != nil {
 		_ = c.AbortWithError(http.StatusInternalServerError, tools.RequestError{
 			Status:        http.StatusInternalServerError,
 			CustomMessage: "Failed to create thumbnail folder",

--- a/api/stream_test.go
+++ b/api/stream_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/TUM-Dev/gocast/mock_dao"
 	"github.com/TUM-Dev/gocast/model"
 	"github.com/TUM-Dev/gocast/tools"
+	"github.com/TUM-Dev/gocast/tools/safepath"
 	"github.com/TUM-Dev/gocast/tools/testutils"
 )
 
@@ -931,6 +932,112 @@ func TestAttachments(t *testing.T) {
 			_ = os.Remove(testFile.Path) // Then cleanup
 		}
 	})
+}
+
+// TestAttachmentCourseNameTraversal makes sure a course name containing path
+// elements cannot place an upload outside of the mass storage directory.
+func TestAttachmentCourseNameTraversal(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mass := t.TempDir()
+	oldMass := tools.Cfg.Paths.Mass
+	tools.Cfg.Paths.Mass = mass
+	defer func() {
+		tools.Cfg.Paths.Mass = oldMass
+	}()
+
+	course := testutils.CourseFPV
+	course.Name = "../../escaped"
+	stream := testutils.StreamFPVLive
+	ctx := tools.TUMLiveContext{User: &testutils.Admin, Course: &course, Stream: &stream}
+
+	body, contentType := multipartFileBody(t, "file", "attachment.txt", "text/plain", []byte("content"))
+
+	var stored string
+	gomino.TestCases{
+		"traversal in course name stays inside mass storage": {
+			Router: func(r *gin.Engine) {
+				fileMock := mock_dao.NewMockFileDao(gomock.NewController(t))
+				fileMock.
+					EXPECT().
+					NewFile(gomock.Any()).
+					DoAndReturn(func(f *model.File) error {
+						stored = f.Path
+						return nil
+					})
+				configGinStreamRestRouter(r, dao.DaoWrapper{
+					StreamsDao: testutils.GetStreamMock(t),
+					CoursesDao: testutils.GetCoursesMock(t),
+					FileDao:    fileMock,
+				}, nil)
+			},
+			Middlewares:  testutils.GetMiddlewares(tools.ErrorHandler, testutils.TUMLiveContext(ctx)),
+			ExpectedCode: http.StatusOK,
+			Body:         body,
+			ContentType:  contentType,
+		},
+	}.
+		Method(http.MethodPost).
+		Url(fmt.Sprintf("/api/stream/%d/files?type=file", stream.ID)).
+		Run(t, testutils.Equal)
+
+	if !safepath.Contains(mass, stored) {
+		t.Fatalf("attachment stored at %s, which is outside of %s", stored, mass)
+	}
+	if _, err := os.Stat(stored); err != nil {
+		t.Fatalf("attachment was not written: %v", err)
+	}
+}
+
+// TestCustomThumbnailCourseNameTraversal is the same check for custom thumbnails.
+func TestCustomThumbnailCourseNameTraversal(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mass := t.TempDir()
+	oldMass := tools.Cfg.Paths.Mass
+	tools.Cfg.Paths.Mass = mass
+	defer func() {
+		tools.Cfg.Paths.Mass = oldMass
+	}()
+
+	course := testutils.CourseFPV
+	course.Name = "../../escaped"
+	stream := testutils.StreamFPVLive
+	ctx := tools.TUMLiveContext{User: &testutils.Admin, Course: &course, Stream: &stream}
+
+	body, contentType := multipartFileBody(t, "file", "thumb.png", "image/png", []byte("fake image"))
+
+	var stored string
+	gomino.TestCases{
+		"traversal in course name stays inside mass storage": {
+			Router: func(r *gin.Engine) {
+				fileMock := mock_dao.NewMockFileDao(gomock.NewController(t))
+				fileMock.
+					EXPECT().
+					SetThumbnail(stream.ID, gomock.Any()).
+					DoAndReturn(func(_ uint, f model.File) error {
+						stored = f.Path
+						return nil
+					})
+				configGinStreamRestRouter(r, dao.DaoWrapper{
+					StreamsDao: testutils.GetStreamMock(t),
+					CoursesDao: testutils.GetCoursesMock(t),
+					FileDao:    fileMock,
+				}, nil)
+			},
+			Middlewares:  testutils.GetMiddlewares(tools.ErrorHandler, testutils.TUMLiveContext(ctx)),
+			ExpectedCode: http.StatusOK,
+			Body:         body,
+			ContentType:  contentType,
+		},
+	}.
+		Method(http.MethodPost).
+		Url(fmt.Sprintf("/api/stream/%d/", stream.ID)).
+		Run(t, testutils.Equal)
+
+	if !safepath.Contains(mass, stored) {
+		t.Fatalf("thumbnail stored at %s, which is outside of %s", stored, mass)
+	}
 }
 
 func TestPutCustomLiveThumbnail(t *testing.T) {

--- a/model/course.go
+++ b/model/course.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 	"time"
 
 	"gorm.io/gorm"
@@ -353,6 +354,34 @@ var courseSlugRegex = regexp.MustCompile(`^[a-zA-Z0-9äöüÄÖÜ\-_]{1,150}$`)
 func (c *Course) BeforeSave(tx *gorm.DB) (err error) {
 	if !courseSlugRegex.MatchString(c.Slug) {
 		return errors.New("invalid course slug")
+	}
+	if err := validateCourseName(c.Name); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateCourseName rejects course names that cannot be meant seriously.
+// Names are free text (they come from TUMOnline as well as from the create
+// course form) and may legitimately contain characters such as "/", so this
+// only rules out what no real course name contains. Everything that builds a
+// filesystem path from the name sanitizes it separately, see
+// tools/safepath.
+func validateCourseName(name string) error {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return errors.New("course name must not be empty")
+	}
+	if len(name) > 255 {
+		return errors.New("course name is too long")
+	}
+	if trimmed == "." || trimmed == ".." {
+		return errors.New("invalid course name")
+	}
+	for _, r := range name {
+		if r == 0 || r < 0x20 || r == 0x7f {
+			return errors.New("course name must not contain control characters")
+		}
 	}
 	return nil
 }

--- a/model/course.go
+++ b/model/course.go
@@ -355,10 +355,7 @@ func (c *Course) BeforeSave(tx *gorm.DB) (err error) {
 	if !courseSlugRegex.MatchString(c.Slug) {
 		return errors.New("invalid course slug")
 	}
-	if err := validateCourseName(c.Name); err != nil {
-		return err
-	}
-	return nil
+	return validateCourseName(c.Name)
 }
 
 // validateCourseName rejects course names that cannot be meant seriously.

--- a/model/course_test.go
+++ b/model/course_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"database/sql"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -102,4 +103,33 @@ func TestShouldGenerateSubtitles(t *testing.T) {
 		assert.True(t, course.ShouldGenerateSubtitles(PRES, 1)) // Default to PRES
 		assert.False(t, course.ShouldGenerateSubtitles(CAM, 1))
 	})
+}
+
+func TestValidateCourseName(t *testing.T) {
+	valid := []string{
+		"Funktionale Programmierung und Verifikation (IN0003)",
+		"Analysis I/II",
+		"Einführung in die Informatik",
+		"../../escaped", // path-like, but harmless once sanitized for filesystem use
+	}
+	for _, name := range valid {
+		if err := validateCourseName(name); err != nil {
+			t.Errorf("validateCourseName(%q) = %v, want nil", name, err)
+		}
+	}
+
+	invalid := map[string]string{
+		"empty":      "",
+		"whitespace": "   ",
+		"dot":        ".",
+		"dotdot":     "..",
+		"nul byte":   "course\x00name",
+		"newline":    "course\nname",
+		"too long":   strings.Repeat("a", 256),
+	}
+	for label, name := range invalid {
+		if err := validateCourseName(name); err == nil {
+			t.Errorf("validateCourseName(%s) = nil, want error", label)
+		}
+	}
 }

--- a/tools/safepath/safepath.go
+++ b/tools/safepath/safepath.go
@@ -1,0 +1,75 @@
+// Package safepath builds filesystem paths from untrusted input, such as
+// user-supplied course names, without letting that input escape the directory
+// it is supposed to live in.
+package safepath
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// ErrOutsideRoot is returned when a joined path would leave its root directory.
+var ErrOutsideRoot = errors.New("resolved path escapes its root directory")
+
+// replacement is substituted for characters that would otherwise change the
+// structure of a path.
+const replacement = "_"
+
+// Component sanitizes s so it can be used as a single path segment. Separators
+// are replaced rather than stripped, so that names which legitimately contain
+// them (e.g. the course "Analysis I/II") stay readable instead of collapsing
+// into each other. Segments that only have meaning to the filesystem ("." and
+// "..") and control characters are replaced as well. An input that carries no
+// usable characters yields a single replacement, never an empty string, so the
+// caller always gets a real directory level.
+func Component(s string) string {
+	s = strings.Map(func(r rune) rune {
+		switch {
+		case r == '/' || r == '\\' || r == 0:
+			return '_'
+		case r < 0x20 || r == 0x7f:
+			return '_'
+		default:
+			return r
+		}
+	}, s)
+
+	s = strings.TrimSpace(s)
+	if s == "" || s == "." || s == ".." {
+		return replacement
+	}
+	return s
+}
+
+// JoinInRoot joins the given elements onto root, sanitizing each one, and
+// verifies that the result is still inside root. The containment check is a
+// backstop: Component should already make an escape impossible, but the two
+// together mean a gap in one does not turn into a write outside the storage
+// directory.
+func JoinInRoot(root string, elems ...string) (string, error) {
+	cleanRoot := filepath.Clean(root)
+
+	sanitized := make([]string, 0, len(elems)+1)
+	sanitized = append(sanitized, cleanRoot)
+	for _, elem := range elems {
+		sanitized = append(sanitized, Component(elem))
+	}
+
+	joined := filepath.Join(sanitized...)
+	if !Contains(cleanRoot, joined) {
+		return "", fmt.Errorf("%w: %s", ErrOutsideRoot, joined)
+	}
+	return joined, nil
+}
+
+// Contains reports whether path lies inside root. root itself counts as
+// contained.
+func Contains(root, path string) bool {
+	rel, err := filepath.Rel(filepath.Clean(root), filepath.Clean(path))
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}

--- a/tools/safepath/safepath_test.go
+++ b/tools/safepath/safepath_test.go
@@ -1,0 +1,78 @@
+package safepath
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestComponent(t *testing.T) {
+	cases := map[string]string{
+		"Funktionale Programmierung (IN0003)": "Funktionale Programmierung (IN0003)",
+		"Analysis I/II":                       "Analysis I_II",
+		"../../escaped":                       ".._.._escaped",
+		"..":                                  "_",
+		".":                                   "_",
+		"":                                    "_",
+		"   ":                                 "_",
+		"/":                                   "_",
+		"a\\b":                                "a_b",
+		"nul\x00byte":                         "nul_byte",
+		"new\nline":                           "new_line",
+	}
+	for in, want := range cases {
+		if got := Component(in); got != want {
+			t.Errorf("Component(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestComponentNeverEscapes(t *testing.T) {
+	root := "/mass"
+	for _, name := range []string{"../../escaped", "..", "/etc", "a/../../b", "....//"} {
+		got := filepath.Join(root, Component(name))
+		if !Contains(root, got) {
+			t.Errorf("Component(%q) escaped root: %s", name, got)
+		}
+	}
+}
+
+func TestJoinInRoot(t *testing.T) {
+	got, err := JoinInRoot("/mass", "../../escaped.2022", "files")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := "/mass/.._.._escaped.2022/files"; got != want {
+		t.Errorf("JoinInRoot = %q, want %q", got, want)
+	}
+}
+
+func TestJoinInRootKeepsEverythingInside(t *testing.T) {
+	root := "/mass/"
+	for _, name := range []string{"../../escaped", "/etc", "..", "a/../../b"} {
+		got, err := JoinInRoot(root, name, "2022.W", "files")
+		if err != nil {
+			t.Fatalf("JoinInRoot(%q) failed: %v", name, err)
+		}
+		if !Contains(root, got) {
+			t.Errorf("JoinInRoot(%q) = %q, which is outside %q", name, got, root)
+		}
+	}
+}
+
+func TestContains(t *testing.T) {
+	cases := []struct {
+		root, path string
+		want       bool
+	}{
+		{"/mass", "/mass/a/b", true},
+		{"/mass", "/mass", true},
+		{"/mass", "/mass/../other", false},
+		{"/mass", "/massive", false},
+		{"/mass", "/etc/passwd", false},
+	}
+	for _, c := range cases {
+		if got := Contains(c.root, c.path); got != c.want {
+			t.Errorf("Contains(%q, %q) = %v, want %v", c.root, c.path, got, c.want)
+		}
+	}
+}

--- a/worker/api/api_server.go
+++ b/worker/api/api_server.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/TUM-Dev/gocast/worker/cfg"
 	"github.com/TUM-Dev/gocast/worker/pb"
+	"github.com/TUM-Dev/gocast/worker/safepath"
 	"github.com/TUM-Dev/gocast/worker/worker"
 )
 
@@ -98,14 +99,22 @@ func (s server) GenerateLivePreview(ctx context.Context, request *pb.LivePreview
 }
 
 func (s server) GenerateSectionImages(ctx context.Context, request *pb.GenerateSectionImageRequest) (*pb.GenerateSectionImageResponse, error) {
-	folder := fmt.Sprintf("%s/%s/%d.%s/sections",
-		cfg.StorageDir, request.CourseName, request.CourseYear, request.CourseTeachingTerm)
-
-	err := os.RemoveAll(folder) // clean up old section images
+	// The course name is free text, so it is sanitized before it becomes a
+	// directory name. Without this, a name containing path elements would make
+	// the RemoveAll below delete a directory outside of the storage directory.
+	folder, err := safepath.JoinInRoot(cfg.StorageDir,
+		request.CourseName,
+		fmt.Sprintf("%d.%s", request.CourseYear, request.CourseTeachingTerm),
+		"sections")
 	if err != nil {
 		return &pb.GenerateSectionImageResponse{}, err
 	}
-	err = os.MkdirAll(folder, os.ModePerm) // make sure folder exists
+
+	err = os.RemoveAll(folder) // clean up old section images
+	if err != nil {
+		return &pb.GenerateSectionImageResponse{}, err
+	}
+	err = os.MkdirAll(folder, 0o755) // make sure folder exists
 	if err != nil {
 		return &pb.GenerateSectionImageResponse{}, err
 	}

--- a/worker/safepath/safepath.go
+++ b/worker/safepath/safepath.go
@@ -1,0 +1,78 @@
+// Package safepath builds filesystem paths from untrusted input, such as
+// user-supplied course names, without letting that input escape the directory
+// it is supposed to live in.
+//
+// This package is a copy of tools/safepath in the main module, which the worker
+// cannot import because it is a separate Go module. Keep the two in sync.
+package safepath
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// ErrOutsideRoot is returned when a joined path would leave its root directory.
+var ErrOutsideRoot = errors.New("resolved path escapes its root directory")
+
+// replacement is substituted for characters that would otherwise change the
+// structure of a path.
+const replacement = "_"
+
+// Component sanitizes s so it can be used as a single path segment. Separators
+// are replaced rather than stripped, so that names which legitimately contain
+// them (e.g. the course "Analysis I/II") stay readable instead of collapsing
+// into each other. Segments that only have meaning to the filesystem ("." and
+// "..") and control characters are replaced as well. An input that carries no
+// usable characters yields a single replacement, never an empty string, so the
+// caller always gets a real directory level.
+func Component(s string) string {
+	s = strings.Map(func(r rune) rune {
+		switch {
+		case r == '/' || r == '\\' || r == 0:
+			return '_'
+		case r < 0x20 || r == 0x7f:
+			return '_'
+		default:
+			return r
+		}
+	}, s)
+
+	s = strings.TrimSpace(s)
+	if s == "" || s == "." || s == ".." {
+		return replacement
+	}
+	return s
+}
+
+// JoinInRoot joins the given elements onto root, sanitizing each one, and
+// verifies that the result is still inside root. The containment check is a
+// backstop: Component should already make an escape impossible, but the two
+// together mean a gap in one does not turn into a write outside the storage
+// directory.
+func JoinInRoot(root string, elems ...string) (string, error) {
+	cleanRoot := filepath.Clean(root)
+
+	sanitized := make([]string, 0, len(elems)+1)
+	sanitized = append(sanitized, cleanRoot)
+	for _, elem := range elems {
+		sanitized = append(sanitized, Component(elem))
+	}
+
+	joined := filepath.Join(sanitized...)
+	if !Contains(cleanRoot, joined) {
+		return "", fmt.Errorf("%w: %s", ErrOutsideRoot, joined)
+	}
+	return joined, nil
+}
+
+// Contains reports whether path lies inside root. root itself counts as
+// contained.
+func Contains(root, path string) bool {
+	rel, err := filepath.Rel(filepath.Clean(root), filepath.Clean(path))
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}

--- a/worker/safepath/safepath_test.go
+++ b/worker/safepath/safepath_test.go
@@ -1,0 +1,78 @@
+package safepath
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestComponent(t *testing.T) {
+	cases := map[string]string{
+		"Funktionale Programmierung (IN0003)": "Funktionale Programmierung (IN0003)",
+		"Analysis I/II":                       "Analysis I_II",
+		"../../escaped":                       ".._.._escaped",
+		"..":                                  "_",
+		".":                                   "_",
+		"":                                    "_",
+		"   ":                                 "_",
+		"/":                                   "_",
+		"a\\b":                                "a_b",
+		"nul\x00byte":                         "nul_byte",
+		"new\nline":                           "new_line",
+	}
+	for in, want := range cases {
+		if got := Component(in); got != want {
+			t.Errorf("Component(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestComponentNeverEscapes(t *testing.T) {
+	root := "/mass"
+	for _, name := range []string{"../../escaped", "..", "/etc", "a/../../b", "....//"} {
+		got := filepath.Join(root, Component(name))
+		if !Contains(root, got) {
+			t.Errorf("Component(%q) escaped root: %s", name, got)
+		}
+	}
+}
+
+func TestJoinInRoot(t *testing.T) {
+	got, err := JoinInRoot("/mass", "../../escaped.2022", "files")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := "/mass/.._.._escaped.2022/files"; got != want {
+		t.Errorf("JoinInRoot = %q, want %q", got, want)
+	}
+}
+
+func TestJoinInRootKeepsEverythingInside(t *testing.T) {
+	root := "/mass/"
+	for _, name := range []string{"../../escaped", "/etc", "..", "a/../../b"} {
+		got, err := JoinInRoot(root, name, "2022.W", "files")
+		if err != nil {
+			t.Fatalf("JoinInRoot(%q) failed: %v", name, err)
+		}
+		if !Contains(root, got) {
+			t.Errorf("JoinInRoot(%q) = %q, which is outside %q", name, got, root)
+		}
+	}
+}
+
+func TestContains(t *testing.T) {
+	cases := []struct {
+		root, path string
+		want       bool
+	}{
+		{"/mass", "/mass/a/b", true},
+		{"/mass", "/mass", true},
+		{"/mass", "/mass/../other", false},
+		{"/mass", "/massive", false},
+		{"/mass", "/etc/passwd", false},
+	}
+	for _, c := range cases {
+		if got := Contains(c.root, c.path); got != c.want {
+			t.Errorf("Contains(%q, %q) = %v, want %v", c.root, c.path, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Reported by Noah Mathern: course names are unsanitized and are used to build filesystem paths, so a course named `../../escaped` writes attachments outside the mass storage directory.

Confirmed on `dev`, and found the same pattern in two more places.

## What was wrong

`course.Name` is free text — only `Slug` is validated (`Course.BeforeSave`). Three places used the raw name as a directory component:

| Site | Effect |
| --- | --- |
| `api/stream.go` `newAttachment` | upload lands outside `Paths.Mass` (the reported issue) |
| `api/stream.go` `putCustomLiveThumbnail` | same, for custom thumbnails |
| `worker/api/api_server.go` `GenerateSectionImages` | builds `<StorageDir>/<CourseName>/<Year>.<Term>/sections` and calls `os.RemoveAll` on it — a recursive **delete** outside the storage root |

Impact is limited: it needs `PermLecture` or course-admin rights, the basename is a UUID (`filepath.Ext` stops at separators, so no targeted overwrite), and the `RemoveAll` target always ends in `<year>.<S|W>/sections`. Still a write and a delete escaping the storage root, plus `os.ModePerm` creating 0777 directories wherever they land.

## The fix

New `safepath` package:

- `Component` neutralizes separators, control characters, and the `.`/`..` segments, and never returns an empty string.
- `JoinInRoot` sanitizes each component and then verifies the joined path is still inside the root — a backstop so a gap in one half doesn't become a write outside the root.

Used at all three sites. `MkdirAll` on those lines goes from `os.ModePerm` to `0o755`.

The worker is a separate Go module and can't import the main module, so it carries a copy (`worker/safepath`) with a note to keep them in sync.

## On validating the name

`Course.BeforeSave` now rejects empty, control-character and `.`/`..` names. It deliberately **does not** reject path separators: course names come from TUMOnline and legitimately contain them (`Analysis I/II`), so rejecting `/` would block valid imports and make existing courses unsaveable. Separators are handled at path construction instead, where such a name becomes one directory level (`Analysis I_II`).

Existing on-disk layout is unchanged for benign names, and stored `file.Path` values are absolute, so already-uploaded files keep resolving.

## Tests

- `tools/safepath` and `worker/safepath` unit tests.
- `TestValidateCourseName`.
- `TestAttachmentCourseNameTraversal` and `TestCustomThumbnailCourseNameTraversal` drive the real handlers with a malicious course name. Both were verified to fail on the unpatched code.

Full `go test ./...` passes in both modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)