### PR TITLE
fix(runner): use a fresh retry backoff per notification

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -240,29 +240,30 @@ func (r *Runner) discarded(job string) bool {
 	return r.discard[job]
 }
 
+// notificationBackoff returns a fresh backoff for sending n. Backoffs are stateful
+// (retry counter and fibonacci sequence), so every notification needs its own.
+func notificationBackoff(n *protobuf.Notification) retry.Backoff {
+	b := retry.NewFibonacci(1 * time.Second)
+	b = retry.WithJitter(500*time.Millisecond, b)
+
+	switch n.Data.(type) {
+	case *protobuf.Notification_StreamEnd,
+		*protobuf.Notification_StreamStart,
+		*protobuf.Notification_VodReady,
+		*protobuf.Notification_ThumbnailReady:
+		// Critical notifications retry indefinitely until delivered or runner shuts down
+		return retry.WithCappedDuration(30*time.Second, b)
+	default:
+		return retry.WithMaxRetries(10, b)
+	}
+}
+
 func (r *Runner) handleNotifications(ctx context.Context) {
-	bounded := retry.NewFibonacci(1 * time.Second)
-	bounded = retry.WithJitter(500*time.Millisecond, bounded)
-	bounded = retry.WithMaxRetries(10, bounded)
-
-	// Critical notifications retry indefinitely until delivered or runner shuts down
-	unbounded := retry.NewFibonacci(1 * time.Second)
-	unbounded = retry.WithJitter(500*time.Millisecond, unbounded)
-	unbounded = retry.WithCappedDuration(30*time.Second, unbounded)
-
 	for {
 		select {
 		case n := <-r.notifications:
 			go func() {
-				b := bounded
-				switch n.Data.(type) {
-				case *protobuf.Notification_StreamEnd,
-					*protobuf.Notification_StreamStart,
-					*protobuf.Notification_VodReady,
-					*protobuf.Notification_ThumbnailReady:
-					b = unbounded
-				}
-				err := retry.Do(ctx, b, r.sendNotification(n))
+				err := retry.Do(ctx, notificationBackoff(n), r.sendNotification(n))
 				if err != nil {
 					r.log.Error("failed to send notification", "error", err,
 						"type", fmt.Sprintf("%T", n.Data))

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -285,3 +285,43 @@ func TestRequestStreamEndIsSafeConcurrently(t *testing.T) {
 	close(release)
 	waitForJob(t, r, job)
 }
+
+// drainBackoff counts how many retries b allows, giving up after limit.
+func drainBackoff(b interface{ Next() (time.Duration, bool) }, limit int) int {
+	for i := 0; i < limit; i++ {
+		if _, stop := b.Next(); stop {
+			return i
+		}
+	}
+	return limit
+}
+
+func TestNotificationBackoffIsNotSharedBetweenNotifications(t *testing.T) {
+	n := &protobuf.Notification{Data: &protobuf.Notification_Heartbeat{}}
+
+	for i := 0; i < 3; i++ {
+		if got := drainBackoff(notificationBackoff(n), 100); got != 10 {
+			t.Fatalf("notification %d: got %d retries, want 10", i, got)
+		}
+	}
+}
+
+func TestNotificationBackoffCriticalRetriesIndefinitelyWithCap(t *testing.T) {
+	n := &protobuf.Notification{Data: &protobuf.Notification_StreamEnd{}}
+
+	// Exhaust one backoff; a fresh one for the next notification must start small again.
+	drainBackoff(notificationBackoff(n), 100)
+	b := notificationBackoff(n)
+	if d, _ := b.Next(); d > 2*time.Second {
+		t.Fatalf("first delay of fresh backoff is %v, want <= 2s", d)
+	}
+	for i := 0; i < 100; i++ {
+		d, stop := b.Next()
+		if stop {
+			t.Fatalf("critical notification backoff stopped after %d retries", i)
+		}
+		if d > 30*time.Second {
+			t.Fatalf("delay %v exceeds 30s cap", d)
+		}
+	}
+}


### PR DESCRIPTION
## Problem
`Runner.handleNotifications` created one bounded and one unbounded `retry.Backoff` up front and shared them across every notification goroutine. go-retry backoffs are stateful:

- `WithMaxRetries` keeps a single attempt counter, so once 10 retries had happened in total (across any notifications), every later non-critical notification (e.g. heartbeats) got no retries for the rest of the runner's lifetime.
- The Fibonacci sequence is shared too, so critical notifications (`StreamStart`, `StreamEnd`, `VodReady`, `ThumbnailReady`) inherited the grown delay of unrelated earlier failures (up to the 30s cap) instead of retrying quickly.

## Fix
Extract `notificationBackoff(n)` which builds a fresh backoff per notification with the same policy as before (fibonacci 1s base, ±500ms jitter; critical: unlimited with 30s cap, others: max 10 retries).

## Tests
- `TestNotificationBackoffIsNotSharedBetweenNotifications`: every non-critical notification gets its full 10 retries.
- `TestNotificationBackoffCriticalRetriesIndefinitelyWithCap`: critical backoff never stops, respects the cap, and a new notification starts from a small delay again.

`go test -race ./...` in `runner/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)